### PR TITLE
NEW Ability to add generated columns in the ORM

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -28,6 +28,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\ORM\FieldType\DBFloat
   ForeignKey:
     class: SilverStripe\ORM\FieldType\DBForeignKey
+  Generated:
+    class: SilverStripe\ORM\FieldType\DBGenerated
   HTMLText:
     class: SilverStripe\ORM\FieldType\DBHTMLText
     properties:

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "guzzlehttp/guzzle": "^7.9",
         "guzzlehttp/psr7": "^2.7",
         "embed/embed": "^4.4.7",
+        "greenlion/php-sql-parser": "^4.7.0",
         "league/csv": "^9.18",
         "m1/env": "^2.2.0",
         "masterminds/html5": "^2.9",

--- a/src/Forms/GridField/GridFieldDataColumns.php
+++ b/src/Forms/GridField/GridFieldDataColumns.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use LogicException;
 use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBGenerated;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\FieldType\DBHTMLVarchar;
 
@@ -329,8 +330,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
             } else {
                 if (!$this->getDoEscapeFields()
                     && is_a($value, DBField::class, false)
-                    && !is_a($value, DBHTMLText::class, false)
-                    && !is_a($value, DBHTMLVarchar::class, false)
+                    && !$this->fieldIsHtml($value)
                 ) {
                     // For DBFields other than HTML variants, if we're not escaping values, get the raw value.
                     $value = $value->RAW();
@@ -390,5 +390,13 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
             $value = str_replace($search ?? '', $replace ?? '', $value ?? '');
         }
         return $value;
+    }
+
+    private function fieldIsHtml(DBField $field): bool
+    {
+        if ($field instanceof DBGenerated) {
+            $field = $field->getChildField();
+        }
+        return is_a($field, DBHTMLText::class) || is_a($field, DBHTMLVarchar::class);
     }
 }

--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -13,6 +13,7 @@ use SilverStripe\Security\Security;
 use SilverStripe\Model\ArrayData;
 use SilverStripe\View\Requirements;
 use SilverStripe\Model\ModelData;
+use SilverStripe\ORM\FieldType\DBGenerated;
 
 /**
  * Adds an "Print" button to the bottom or top of a GridField.
@@ -250,7 +251,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
 
                     // The value is used in a template, so to prevent XSS attacks we can't allow an HTML field here.
                     // Getting the raw string here means it will end up being default-casted to DBText which is safe.
-                    if (is_a($value, DBHTMLText::class, false) || is_a($value, DBHTMLVarchar::class, false)) {
+                    if ($this->valueIsHtmlField($value)) {
                         $value = $value->__toString();
                     }
                     $itemRow->push(new ArrayData([
@@ -316,5 +317,13 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
         $this->printHasHeader = $bool;
 
         return $this;
+    }
+
+    private function valueIsHtmlField(mixed $value): bool
+    {
+        if ($value instanceof DBGenerated) {
+            $value = $value->getChildField();
+        }
+        return is_a($value, DBHTMLText::class) || is_a($value, DBHTMLVarchar::class);
     }
 }

--- a/src/ORM/Connect/DBConnector.php
+++ b/src/ORM/Connect/DBConnector.php
@@ -83,6 +83,23 @@ abstract class DBConnector
         throw new DuplicateEntryException($msg, $keyName, $duplicatedValue, $sql, $parameters);
     }
 
+    protected function valueForGeneratedColumnError(
+        string $msg,
+        ?string $column,
+        ?string $table,
+        ?string $sql = null,
+        array $parameters = []
+    ): void {
+        // Format query if given
+        if (!empty($sql)) {
+            $formatter = SQLFormatter::create();
+            $formattedSQL = $formatter->formatPlain($sql);
+            $msg = "Couldn't run query:\n\n{$formattedSQL}\n\n{$msg}";
+        }
+
+        throw new GeneratedColumnValueException($msg, $column, $table, $sql, $parameters);
+    }
+
     /**
      * Determine if this SQL statement is a destructive operation (write or ddl)
      *

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -528,7 +528,7 @@ abstract class DBSchemaManager
             // Updated index
             $this->transAlterIndex($table, $index, $spec);
             $this->alterationMessage(
-                "Index $table.$index: changed to $specString <i class=\"build-info-before\">(from $oldSpecString)</i>",
+                "Index $table.$index: changed to '$specString' <i class=\"build-info-before\">(from '$oldSpecString')</i>",
                 "changed"
             );
         }
@@ -761,13 +761,21 @@ abstract class DBSchemaManager
         // Get the version of the field as we would create it. This is used for comparison purposes to see if the
         // existing field is different to what we now want
         if (is_array($spec_orig)) {
-            $spec_orig = $this->{$spec_orig['type']}($spec_orig['parts']);
+            $specArray = $spec_orig;
+            $generated = $specArray['generated'] ?? false;
+            $spec_orig = $this->{$specArray['type']}($specArray['parts']);
+            // Update the spec to include the generation expression and storage type
+            if ($generated !== false) {
+                $specValue = $this->makeGenerated($specValue, $specArray, $generated['expression'], $generated['type']);
+                $spec_orig = $this->makeGenerated($spec_orig, $specArray, $generated['expression'], $generated['type']);
+            }
+            unset($specArray);
         }
 
         if ($newTable || $fieldValue == '') {
             $this->transCreateField($table, $field, $spec_orig);
             $this->alterationMessage("Field $table.$field: created as $spec_orig", "created");
-        } elseif ($fieldValue != $specValue) {
+        } elseif ($fieldValue !== $specValue) {
             // If enums/sets are being modified, then we need to fix existing data in the table.
             // Update any records where the enum is set to a legacy value to be set to the default.
             $enumValuesExpr = "/^(enum|set)\\s*\\(['\"](?<values>[^'\"]+)['\"]\\).*/i";
@@ -800,11 +808,33 @@ abstract class DBSchemaManager
                 }
             }
             $this->transAlterField($table, $field, $spec_orig);
+            if ($this->needRebuildColumn($fieldValue, $spec_orig)) {
+                if (!isset($this->schemaUpdateTransaction[$table]['advancedOptions'])) {
+                    $this->schemaUpdateTransaction[$table]['advancedOptions'] = [];
+                }
+                $this->schemaUpdateTransaction[$table]['advancedOptions'] = array_merge(
+                    $this->schemaUpdateTransaction[$table]['advancedOptions'],
+                    ['rebuildCols' => [$field => true]],
+                );
+            }
             $this->alterationMessage(
-                "Field $table.$field: changed to $specValue <i class=\"build-info-before\">(from {$fieldValue})</i>",
+                "Field $table.$field: changed to '$specValue' <i class=\"build-info-before\">(from '$fieldValue')</i>",
                 "changed"
             );
         }
+    }
+
+    /**
+     * Check whether a column needs to be rebuilt by comparing the existing column spec and the new column spec.
+     *
+     * Subclasses should implement this method to match logic for their SQL server.
+     * For example some servers may have different rules about whether a generated column
+     * can swap between stored and virtual using CHANGE COLUMN
+     */
+    protected function needRebuildColumn(string $existingSpec, string $newSpec): bool
+    {
+        // Assume columns don't need rebuilding for BC. A future major release will make this method abstract.
+        return false;
     }
 
     /**
@@ -885,6 +915,17 @@ abstract class DBSchemaManager
                 echo "<li class=\"$class\">$message</li>";
             }
         }
+    }
+
+    /**
+     * Take the column spec and convert it into the spec for a generated column.
+     */
+    public function makeGenerated(string $spec, array $origSpec, string $expression, string $generationType): string
+    {
+        // Just return the original spec, for BC. A future major release will make this method abstract.
+        // No value will actually get generated if subclasses don't implement this method, so this will just
+        // be taking space in the DB for no value but at least the site won't just fail to build altogether.
+        return $spec;
     }
 
     /**

--- a/src/ORM/Connect/GeneratedColumnValueException.php
+++ b/src/ORM/Connect/GeneratedColumnValueException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+/**
+ * Exception for errors related to setting values on a generated column
+ */
+class GeneratedColumnValueException extends DatabaseException
+{
+    private ?string $column = null;
+
+    private ?string $table = null;
+
+    /**
+     * Constructs the database exception
+     *
+     * @param string $message The Exception message to throw.
+     * @param string|null $column The name of the column which the error is for
+     * @param string|null $table The name of the table which the error is for
+     * @param string|null $sql The SQL executed for this query
+     * @param array $parameters The parameters given for this query, if any
+     */
+    public function __construct(
+        string $message = '',
+        ?string $column = null,
+        ?string $table = null,
+        ?string $sql = null,
+        array $parameters = []
+    ) {
+        parent::__construct($message, sql: $sql, parameters: $parameters);
+        $this->column = $column;
+        $this->table = $table;
+    }
+
+    /**
+     * Get the name of the column which the error is for
+     */
+    public function getColumn(): ?string
+    {
+        return $this->column;
+    }
+
+    /**
+     * Get the name of the table which the error is for
+     */
+    public function getTable(): ?string
+    {
+        return $this->table;
+    }
+}

--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -5,6 +5,12 @@ namespace SilverStripe\ORM\Connect;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use LogicException;
+use PHPSQLParser\Options;
+use PHPSQLParser\PHPSQLCreator;
+use PHPSQLParser\PHPSQLParser;
+use PHPSQLParser\utils\ExpressionType;
+use PHPSQLParser\utils\PHPSQLParserConstants;
+use SilverStripe\ORM\FieldType\DBGenerated;
 
 /**
  * Represents schema management object for MySQL
@@ -87,6 +93,9 @@ class MySQLSchemaManager extends DBSchemaManager
         }
         if ($alteredFields) {
             foreach ($alteredFields as $k => $v) {
+                if (isset($advancedOptions['rebuildCols'][$k]) && $advancedOptions['rebuildCols'][$k] === true) {
+                    continue;
+                }
                 $alterList[] = "CHANGE \"$k\" \"$k\" $v";
             }
         }
@@ -96,6 +105,16 @@ class MySQLSchemaManager extends DBSchemaManager
                 if (!array_key_exists('drop', $v) || !$v['drop']) {
                     $alterList[] = "ADD " . $this->getIndexSqlDefinition($k, $v);
                 }
+            }
+        }
+        if (isset($advancedOptions['rebuildCols'])) {
+            foreach ($advancedOptions['rebuildCols'] as $k => $v) {
+                if ($v !== true || !isset($alteredFields[$k])) {
+                    continue;
+                }
+                $v = $alteredFields[$k];
+                $alterList[] = "DROP \"$k\"";
+                $alterList[] = "ADD \"$k\" $v";
             }
         }
 
@@ -270,7 +289,14 @@ class MySQLSchemaManager extends DBSchemaManager
                 $fieldSpec .= " default " . $this->database->quoteString($field['Default']);
             }
             if ($field['Extra']) {
-                $fieldSpec .= " " . $field['Extra'];
+                $extra = $field['Extra'];
+                if (str_ends_with($extra, ' GENERATED')) {
+                    $expression = $this->query(
+                        "SELECT GENERATION_EXPRESSION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{$table}' AND COLUMN_NAME = '{$field['Field']}'"
+                    )->record()['GENERATION_EXPRESSION'];
+                    $extra =  'AS (' . $this->normaliseGeneratedColumnExpression($expression) . ') ' . $extra;
+                }
+                $fieldSpec .= ' ' . str_replace(' GENERATED', '', $extra);
             }
 
             $fieldList[$field['Field']] = $fieldSpec;
@@ -404,6 +430,16 @@ class MySQLSchemaManager extends DBSchemaManager
         }
     }
 
+    public function makeGenerated(string $spec, array $origSpec, string $expression, string $generationType): string
+    {
+        $expression = $this->normaliseGeneratedColumnExpression($expression);
+        // Remove any default and nullability from the schema
+        $default = $this->defaultClause($origSpec['parts'] ?? []);
+        $spec = str_replace([$default, ' not null'], '', $spec);
+        // Add generated column bits
+        return "$spec AS ($expression) $generationType";
+    }
+
     /**
      * Return a boolean type-formatted string
      *
@@ -449,22 +485,10 @@ class MySQLSchemaManager extends DBSchemaManager
         //DB::requireField($this->tableName, $this->name, "decimal($this->wholeSize,$this->decimalSize)");
         // Avoid empty strings being put in the db
         if ($values['precision'] == '') {
-            $precision = 1;
-        } else {
-            $precision = $values['precision'];
+            $values['precision'] = 1;
         }
 
-        // Fix format of default value to match precision
-        if (isset($values['default']) && is_numeric($values['default'])) {
-            $decs = strpos($precision ?? '', ',') !== false
-                    ? (int) substr($precision, strpos($precision, ',') + 1)
-                    : 0;
-            $values['default'] = number_format($values['default'] ?? 0.0, $decs ?? 0, '.', '');
-        } else {
-            unset($values['default']);
-        }
-
-        return "decimal($precision) not null" . $this->defaultClause($values);
+        return 'decimal(' . $values['precision'] . ') not null' . $this->defaultClause($values);
     }
 
     /**
@@ -643,8 +667,162 @@ class MySQLSchemaManager extends DBSchemaManager
     protected function defaultClause($values)
     {
         if (isset($values['default'])) {
+            // Update default for decimal data type
+            if (isset($values['datatype']) && $values['datatype'] === 'decimal') {
+                if (!is_numeric($values['default']) || !isset($values['precision'])) {
+                    return '';
+                }
+                // Fix format of default value to match precision
+                $precision = $values['precision'];
+                $decs = strpos($precision ?? '', ',') !== false
+                    ? (int) substr($precision, strpos($precision, ',') + 1)
+                    : 0;
+                $values['default'] = number_format($values['default'] ?? 0.0, $decs ?? 0, '.', '');
+            }
             return ' default ' . $this->database->quoteString($values['default']);
         }
         return '';
+    }
+
+    /**
+     * Check whether a column needs to be rebuilt.
+     * Logic based on https://dev.mysql.com/doc/refman/8.4/en/alter-table-generated-columns.html
+     */
+    protected function needRebuildColumn(string $existingSpec, string $newSpec): bool
+    {
+        // Virtual generated columns cannot be altered to stored generated columns, or vice versa
+        // Non-generated columns can be altered to stored but not virtual generated columns
+        // Stored but not virtual generated columns can be altered to non-generated columns
+        $existingSpecType = $this->getGeneratedType($existingSpec);
+        $newSpecType = $this->getGeneratedType($newSpec);
+
+        // If neither spec is generated, we can just use ALTER
+        if (!$existingSpecType && !$newSpecType) {
+            return false;
+        }
+
+        // Virtual generated columns cannot be altered to stored generated columns
+        // Virtual generated columns cannot be altered to non-generated columns
+        if ($existingSpecType === DBGenerated::GENERATION_VIRTUAL) {
+            if ($newSpecType !== DBGenerated::GENERATION_VIRTUAL) {
+                return true;
+            }
+            return false;
+        }
+
+        // Stored generated columns cannot be altered to virtual generated columns
+        // Stored generated columns can be altered to non-generated columns
+        if ($existingSpecType === DBGenerated::GENERATION_STORED) {
+            if ($newSpecType === DBGenerated::GENERATION_VIRTUAL) {
+                return true;
+            }
+            return false;
+        }
+
+        // Non-generated columns can be altered to stored but not virtual generated columns
+        return $newSpecType === DBGenerated::GENERATION_VIRTUAL;
+    }
+
+    /**
+     * Get what type of storage is used for a generated column, or null if not a generated column.
+     */
+    private function getGeneratedType(string $spec): ?string
+    {
+        // If it ends with "STORED" or "VIRTUAL", it's a generated column spec.
+        preg_match('/(STORED|VIRTUAL)$/i', $spec, $matches);
+        return strtoupper($matches[1] ?? '');
+    }
+
+    /**
+     * Normalises a MySQL generated column expression.
+     * This is needed to robustly validate whether the expression we want matches the expression
+     * that's already in the database, because MySQL sometimes makes changes internally that we
+     * need to normalise out, such as:
+     * - escaping quotes
+     * - double-escaping backslashes
+     * - adding the charset before explicit strings
+     * - changing case of keywords
+     * - using backticks instead of ANSI quotes around columns names
+     * - adding spaces around operators
+     */
+    private function normaliseGeneratedColumnExpression(string $expression): string
+    {
+        // Clean up string literals. Easier to do here than in the AST because the
+        // escaped quotes MySQL gives us change the representation of the parsed string.
+        $expression = preg_replace_callback(
+            // Both \' and '' are valid escape sequences for a single quote in a string literal
+            // see https://dev.mysql.com/doc/refman/8.4/en/string-literals.html
+            "/\\\\'(?:[^']|''|\\\\\\\\')*\\\\'/",
+            function ($matches) {
+                // Replace escaped quotes around the string literal with single unescaped quotes
+                $x = preg_replace("/^\\\\'(.*)\\\\'$/", "'$1'", $matches[0]);
+                // Tidy up escaped backslashes, e.g. for FQCN
+                return str_replace('\\\\\\\\', '\\\\', $x);
+            },
+            $expression
+        );
+
+        // Parse and normalise the AST (needs to be a valid SQL command so prepend with SELECT)
+        $parser = new PHPSQLParser(options: [Options::ANSI_QUOTES => true]);
+        $parsed = $parser->parse('SELECT ' . $expression);
+        $this->normaliseExpressionAST($parsed);
+        // Render back out as an SQL expression string
+        $sqlCreator = new PHPSQLCreator($parsed);
+        return preg_replace('/^SELECT /', '', $sqlCreator->created);
+    }
+
+    private function normaliseExpressionAST(array &$ast, ?array &$parent = null, string|int $i = 'root'): void
+    {
+        if (isset($ast['base_expr']) && isset($ast['expr_type'])) {
+            // Normalise casing for reserved keywords
+            if (PHPSQLParserConstants::getInstance()->isReserved(strtoupper($ast['base_expr']))) {
+                $ast['base_expr'] = strtoupper($ast['base_expr']);
+            }
+
+            // Normalise column references
+            if ($ast['expr_type'] === ExpressionType::COLREF) {
+                // Remove unnecessary charset references
+                $charset = '_' . MySQLDatabase::config()->get('charset');
+                if ($ast['base_expr'] === $charset) {
+                    unset($parent[$i]);
+                // Normalise column references to be ANSI quotes
+                } elseif (isset($ast['no_quotes'])
+                    // If a column reference starts with an underscore and precedes a constant value, it's a charset (e.g. _utf8)
+                    && !(str_starts_with($ast['base_expr'], '_') && isset($parent[$i + 1]['expr_type']) && $parent[$i + 1]['expr_type'] === ExpressionType::CONSTANT)) {
+                    // Replace backtick quotes from around column references with ANSI quotes
+                    $ast['base_expr'] = $this->quoteColumnSpecString(implode($ast['no_quotes']['delim'] ?: '', $ast['no_quotes']['parts']));
+                }
+            }
+
+            // MySQL sometimes puts unnecessary brackets around various clauses.
+            // We need to remove those in case we didn't put them in our original expression.
+            // We target specific clauses because these are known scenarios where brackets are added but not necessary.
+            // We can't just blindly collapse all bracket expressions because in many cases brackets will affect
+            // operation order, e.g. "2 x (1 + 3)"
+            if (is_int($i) && $ast['expr_type'] === ExpressionType::BRACKET_EXPRESSION && is_array($ast['sub_tree'])) {
+                $children = $ast['sub_tree'];
+                // e.g. "(x + y * z)" as the whole expression
+                if ($i === 0 && !isset($parent[$i + 1])
+                    // e.g. "(CASE WHEN x=y THEN x ELSE y END)"
+                    || (strtoupper($children[0]['base_expr']) === 'CASE' && strtoupper($children[array_key_last($children)]['base_expr']) === 'END')
+                ) {
+                    $ast['expr_type'] = ExpressionType::EXPRESSION;
+                // e.g. "CASE WHEN (x=y) THEN"
+                } elseif (isset($parent[$i - 1]['base_expr']) && strtoupper($parent[$i - 1]['base_expr']) === 'WHEN') {
+                    $this->normaliseExpressionAST($children, $ast, 'sub_tree');
+                    array_splice($parent, $i, 1, $children);
+                    // No need to recurse into children, we already normalised them before popping them back into the parent AST
+                    return;
+                }
+            }
+        }
+
+        // Recurse into sub-elements.
+        for ($n = count($ast) - 1; $n >= 0; $n--) {
+            $childIndex = array_keys($ast)[$n];
+            if (is_array($ast[$childIndex])) {
+                $this->normaliseExpressionAST($ast[$childIndex], $ast, $n);
+            }
+        }
     }
 }

--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -408,21 +408,36 @@ class MySQLiConnector extends DBConnector
      */
     private function throwRelevantError(string $message, int $code, int $errorLevel, ?string $sql, array $parameters): void
     {
-        if ($errorLevel === E_USER_ERROR && ($code === 1062 || $code === 1586)) {
-            // error 1062 is for a duplicate entry
-            // see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_dup_entry
-            // error 1586 is ALSO for a duplicate entry and uses the same error message
-            // see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_dup_entry_with_key_name
-            preg_match('/Duplicate entry \'(?P<val>[^\']+)\' for key \'?(?P<key>[^\']+)\'?/', $message, $matches);
-            // MySQL includes the table name in the key, but MariaDB doesn't.
-            $key = $matches['key'];
-            if (str_contains($key ?? '', '.')) {
-                $parts = explode('.', $key);
-                $key = array_pop($parts);
+        if ($errorLevel === E_USER_ERROR) {
+            switch ($code) {
+                // error 1062 is for a duplicate entry
+                // see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_dup_entry
+                // see https://mariadb.com/docs/general-resources/development-articles/mariadb-internals/using-mariadb-with-your-programs-api/error-codes/mariadb-error-codes-1000-to-1099/e1062
+                case 1062:
+                // error 1586 is ALSO for a duplicate entry and uses the same error message
+                // see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_dup_entry_with_key_name
+                // see https://mariadb.com/docs/general-resources/development-articles/mariadb-internals/using-mariadb-with-your-programs-api/error-codes/mariadb-error-codes-1500-to-1599/e1586
+                case 1586:
+                    preg_match('/Duplicate entry \'(?P<val>[^\']+)\' for key \'?(?P<key>[^\']+)\'?/', $message, $matches);
+                    // MySQL includes the table name in the key, but MariaDB doesn't.
+                    $key = $matches['key'];
+                    if (str_contains($key ?? '', '.')) {
+                        $parts = explode('.', $key);
+                        $key = array_pop($parts);
+                    }
+                    $this->duplicateEntryError($message, $key, $matches['val'], $sql, $parameters);
+                    return;
+                // error 3105 is for trying to set a value for a generated column in MySQL
+                // see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_non_default_value_for_generated_column
+                // Note this error is for MySQL - MariaDB has no error with this code, it emits a warning instead.
+                case 3105:
+                    preg_match('/The value specified for generated column \'(?P<col>[^\']+)\' in table \'(?P<table>[^\']+)\' is not allowed/', $message, $matches);
+                    $this->valueForGeneratedColumnError($message, $matches['col'], $matches['table'], $sql, $parameters);
+                    return;
             }
-            $this->duplicateEntryError($message, $key, $matches['val'], $sql, $parameters);
-        } else {
-            $this->databaseError($message, $errorLevel, $sql, $parameters);
         }
+
+        // Fallback on a generic database error
+        $this->databaseError($message, $errorLevel, $sql, $parameters);
     }
 }

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -47,6 +47,7 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\View\SSViewer;
 use SilverStripe\Model\ModelData;
+use SilverStripe\ORM\Connect\GeneratedColumnValueException;
 use SilverStripe\ORM\Filters\WithinRangeFilter;
 use stdClass;
 
@@ -156,6 +157,13 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
      * This will not be enforced when using low-level ORM functionality to query data e.g. SQLSelect or DB::query()
      */
     private static bool $must_use_primary_db = false;
+
+    /**
+     * Allows you to skip fetching generated columns in onAfterWrite.
+     * Setting this to true will skip fetching ALL generated columns for this class.
+     * Setting this to an array lets you name specific columns to skip, while still fetching others.
+     */
+    private static bool|array $skip_fetch_generated_columns_after_write = false;
 
     /**
      * Data stored in this objects database record. An array indexed by fieldname.
@@ -1296,6 +1304,32 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
      */
     protected function onAfterWrite()
     {
+        // Fetch values from any generated columns
+        // since we may have updated the columns they are based on
+        $skipGeneratedColumns = static::config()->get('skip_fetch_generated_columns_after_write');
+        if ($skipGeneratedColumns !== true) {
+            $schema = DataObject::getSchema();
+            $generatedFields = array_keys($schema->generatedFields(static::class));
+            if (is_array($skipGeneratedColumns)) {
+                $generatedFields = array_diff($generatedFields, $skipGeneratedColumns);
+            }
+            // Only fetch if we have generated columns that aren't skipped
+            if (!empty($generatedFields)) {
+                $select = static::get()
+                    ->filter(['ID' => $this->ID])
+                    ->sort(null)
+                    ->limit(1)
+                    ->dataQuery()
+                    ->getFinalisedQuery();
+                $columns = [];
+                foreach ($generatedFields as $fieldName) {
+                    $columns[] = $schema->sqlColumnForField(static::class, $fieldName);
+                }
+                $select->setSelect($columns);
+                $this->update($select->execute()->record());
+            }
+        }
+
         $dummy = null;
         $this->extend('onAfterWrite', $dummy);
     }
@@ -1639,8 +1673,11 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 $this->writeBaseRecord($baseTable, $now);
                 // Write the DB manipulation for all changed fields
                 $this->writeManipulation($baseTable, $now, $isNewRecord);
-            } catch (DuplicateEntryException $e) {
-                throw new ValidationException($this->buildValidationResultForDuplicateEntry($e));
+            } catch (DuplicateEntryException|GeneratedColumnValueException $e) {
+                if ($e instanceof DuplicateEntryException) {
+                    throw new ValidationException($this->buildValidationResultForDuplicateEntry($e));
+                }
+                throw new ValidationException($this->buildValidationResultForGeneratedColumnError($e));
             }
 
             // If there's any relations that couldn't be saved before, save them now (we have an ID here)
@@ -4718,6 +4755,21 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 ['type' => $singleName, 'fields' => implode(', ', $duplicateFieldNames)]
             ));
         }
+        return $validationResult;
+    }
+
+    private function buildValidationResultForGeneratedColumnError(GeneratedColumnValueException $exception): ValidationResult
+    {
+        $column = $exception->getColumn();
+        $validationResult = ValidationResult::create();
+        $validationResult->addFieldError(
+            $column,
+            _t(
+                __CLASS__ . '.VALUE_SET_FOR_GENERATED_COLUMN',
+                'Cannot set a value for generated field "{field}"',
+                ['field' => $this->fieldLabel($column)]
+            )
+        );
         return $validationResult;
     }
 }

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -16,6 +16,7 @@ use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\Connect\DBSchemaManager;
 use SilverStripe\ORM\FieldType\DBComposite;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBGenerated;
 
 /**
  * Provides dataobject and database schema mapping functionality
@@ -90,6 +91,11 @@ class DataObjectSchema
      * @var array
      */
     protected $compositeFields = [];
+
+    /**
+     * Cache of generated database column specs
+     */
+    protected array $generatedFields = [];
 
     /**
      * Cache of table names
@@ -495,6 +501,31 @@ class DataObjectSchema
     }
 
     /**
+     * Returns a list of all the generated database columns on the class.
+     * Will check all applicable ancestor classes and aggregate results if $aggregated is true.
+     *
+     * @param string $class Name of class to check
+     * @param bool $aggregated Include fields in entire hierarchy, rather than just on this table
+     */
+    public function generatedFields(string $class, bool $aggregated = true): array
+    {
+        $class = ClassInfo::class_name($class);
+        if ($class === DataObject::class) {
+            return [];
+        }
+        $this->cacheDatabaseFields($class);
+
+        $generatedFields = $this->generatedFields[$class];
+        if (!$aggregated) {
+            return $generatedFields;
+        }
+
+        // Recursively merge
+        $parentFields = $this->generatedFields(get_parent_class($class));
+        return array_merge($generatedFields, array_diff_key($parentFields, $generatedFields));
+    }
+
+    /**
      * Cache all database and composite fields for the given class.
      * Will do nothing if already cached
      *
@@ -507,6 +538,7 @@ class DataObjectSchema
             return;
         }
         $compositeFields = [];
+        $generatedFields = [];
         $dbFields = [];
 
         // Ensure fixed fields appear at the start
@@ -522,8 +554,12 @@ class DataObjectSchema
         $db = Config::inst()->get($class, 'db', Config::UNINHERITED) ?: [];
         foreach ($db as $fieldName => $fieldSpec) {
             $fieldClass = strtok($fieldSpec ?? '', '(');
-            if (singleton($fieldClass) instanceof DBComposite) {
+            $singleton = singleton($fieldClass);
+            if ($singleton instanceof DBComposite) {
                 $compositeFields[$fieldName] = $fieldSpec;
+            } elseif ($singleton instanceof DBGenerated) {
+                $generatedFields[$fieldName] = $fieldSpec;
+                $dbFields[$fieldName] = $fieldSpec;
             } else {
                 $dbFields[$fieldName] = $fieldSpec;
             }
@@ -570,6 +606,7 @@ class DataObjectSchema
         // Return cached results
         $this->databaseFields[$class] = $dbFields;
         $this->compositeFields[$class] = $compositeFields;
+        $this->generatedFields[$class] = $generatedFields;
     }
 
     /**

--- a/src/ORM/FieldType/DBBigInt.php
+++ b/src/ORM/FieldType/DBBigInt.php
@@ -4,7 +4,6 @@ namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
 use SilverStripe\Core\Validation\FieldValidation\BigIntFieldValidator;
-use SilverStripe\ORM\DB;
 
 /**
  * Represents a signed 8 byte integer field with a range between -9223372036854775808 and 9223372036854775807
@@ -35,16 +34,15 @@ class DBBigInt extends DBInt
         BigIntFieldValidator::class,
     ];
 
-    public function requireField(): void
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
     {
-        $parts = [
-            'datatype' => 'bigint',
-            'precision' => 8,
-            'null' => 'not null',
-            'default' => $this->defaultVal,
-            'arrayValue' => $this->arrayValue
-        ];
-        $values = ['type' => 'bigint', 'parts' => $parts];
-        DB::require_field($this->tableName, $this->name, $values);
+        $spec = parent::getFieldSpec();
+        $spec['type'] = 'bigint';
+        $spec['parts']['datatype'] = 'bigint';
+        $spec['parts']['precision'] = 8;
+        return $spec;
     }
 }

--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -27,6 +27,14 @@ class DBBoolean extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = [
             'datatype' => 'tinyint',
             'precision' => 1,
@@ -35,8 +43,7 @@ class DBBoolean extends DBField
             'default' => (int) $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
-        $values = ['type' => 'boolean', 'parts' => $parts];
-        DB::require_field($this->tableName, $this->name, $values);
+        return ['type' => 'boolean', 'parts' => $parts];
     }
 
     public function setDefaultValue(mixed $defaultValue): static

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -2,8 +2,6 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\ORM\DB;
-
 /**
  * Represents a classname selector, which respects obsolete clasess.
  */
@@ -11,24 +9,15 @@ class DBClassName extends DBEnum
 {
     use DBClassNameTrait;
 
-    public function requireField(): void
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
     {
-        $parts = [
-            'datatype' => 'enum',
-            'enums' => $this->getEnumObsolete(),
-            'character set' => 'utf8',
-            'collate' => 'utf8_general_ci',
-            'default' => $this->getDefault(),
-            'table' => $this->getTable(),
-            'arrayValue' => $this->arrayValue
-        ];
-
-        $values = [
-            'type' => 'enum',
-            'parts' => $parts
-        ];
-
-        DB::require_field($this->getTable(), $this->getName(), $values);
+        $spec = parent::getFieldSpec();
+        $spec['parts']['character set'] = 'utf8';
+        $spec['parts']['collate'] = 'utf8_general_ci';
+        return $spec;
     }
 
     public function getDefault(): string

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -489,9 +489,16 @@ class DBDate extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = ['datatype' => 'date', 'arrayValue' => $this->arrayValue];
-        $values = ['type' => 'date', 'parts' => $parts];
-        DB::require_field($this->tableName, $this->name, $values);
+        return ['type' => 'date', 'parts' => $parts];
     }
 
     /**

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -8,14 +8,12 @@ use IntlDateFormatter;
 use InvalidArgumentException;
 use SilverStripe\Forms\DatetimeField;
 use SilverStripe\Forms\FormField;
-use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\View\TemplateGlobalProvider;
 use SilverStripe\Model\ModelData;
 use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
 use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
-use SilverStripe\ORM\Tests\Search\SearchContextTest\WithinRangeFilterModel;
 
 /**
  * Represents a date-time field.
@@ -157,17 +155,15 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         return $this->Format($dateFormat . ' ' . $timeFormat, $member->getLocale());
     }
 
-    public function requireField(): void
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
     {
-        $parts = [
-            'datatype' => 'datetime',
-            'arrayValue' => $this->arrayValue
-        ];
-        $values = [
-            'type' => 'datetime',
-            'parts' => $parts
-        ];
-        DB::require_field($this->tableName, $this->name, $values);
+        $spec = parent::getFieldSpec();
+        $spec['type'] = 'datetime';
+        $spec['parts']['datatype'] = 'datetime';
+        return $spec;
     }
 
     /**

--- a/src/ORM/FieldType/DBDecimal.php
+++ b/src/ORM/FieldType/DBDecimal.php
@@ -65,6 +65,14 @@ class DBDecimal extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = [
             'datatype' => 'decimal',
             'precision' => "$this->wholeSize,$this->decimalSize",
@@ -72,12 +80,10 @@ class DBDecimal extends DBField
             'arrayValue' => $this->arrayValue
         ];
 
-        $values = [
+        return [
             'type' => 'decimal',
             'parts' => $parts
         ];
-
-        DB::require_field($this->tableName, $this->name, $values);
     }
 
     public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static

--- a/src/ORM/FieldType/DBDouble.php
+++ b/src/ORM/FieldType/DBDouble.php
@@ -10,14 +10,15 @@ use SilverStripe\ORM\DB;
  */
 class DBDouble extends DBFloat
 {
-
-    public function requireField(): void
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string
     {
         // HACK: MSSQL does not support double so we're using float instead
         if (DB::get_conn() instanceof MySQLDatabase) {
-            DB::require_field($this->tableName, $this->name, "double");
-        } else {
-            DB::require_field($this->tableName, $this->name, "float");
+            return 'double';
         }
+        return 'float';
     }
 }

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -100,6 +100,14 @@ class DBEnum extends DBString implements Resettable
 
     public function requireField(): void
     {
+        DB::require_field($this->getTable(), $this->getName(), $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
 
@@ -113,12 +121,10 @@ class DBEnum extends DBString implements Resettable
             'arrayValue' => $this->arrayValue
         ];
 
-        $values = [
+        return [
             'type' => 'enum',
             'parts' => $parts
         ];
-
-        DB::require_field($this->getTable(), $this->getName(), $values);
     }
 
     /**

--- a/src/ORM/FieldType/DBFloat.php
+++ b/src/ORM/FieldType/DBFloat.php
@@ -25,14 +25,21 @@ class DBFloat extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = [
             'datatype' => 'float',
             'null' => 'not null',
             'default' => $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
-        $values = ['type' => 'float', 'parts' => $parts];
-        DB::require_field($this->tableName, $this->name, $values);
+        return ['type' => 'float', 'parts' => $parts];
     }
 
     public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static

--- a/src/ORM/FieldType/DBGenerated.php
+++ b/src/ORM/FieldType/DBGenerated.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+use InvalidArgumentException;
+use SilverStripe\Assets\Storage\DBFile;
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Model\ModelData;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Filters\SearchFilter;
+
+/**
+ * A column which gets generated based on some SQL statement.
+ * This can be stored (generated whenever columns in the generation statement are updated), or virtual (generated on the fly when accessed).
+ */
+class DBGenerated extends DBField
+{
+    public const string GENERATION_STORED = 'STORED';
+
+    public const string GENERATION_VIRTUAL = 'VIRTUAL';
+
+    /**
+     * DBField classes which must not be used as the underlying data representation for a generated column.
+     */
+    private static array $invalid_child_field_types = [
+        DBClassName::class,
+        DBClassNameVarchar::class,
+        DBComposite::class,
+        DBFile::class,
+        DBForeignKey::class,
+        DBGenerated::class,
+        DBPolymorphicForeignKey::class,
+        DBPrimaryKey::class,
+    ];
+
+    private DBField $childField;
+
+    private string $sqlExpression;
+
+    private string $generationType;
+
+    public function __construct(
+        ?string $name = null,
+        string $fieldSpec = '',
+        string $sqlExpression = '',
+        string $generationType = DBGenerated::GENERATION_VIRTUAL
+    ) {
+        if (!in_array($generationType, [DBGenerated::GENERATION_STORED, DBGenerated::GENERATION_VIRTUAL])) {
+            throw new InvalidArgumentException('$generationType must be "STORED" or "VIRTUAL"');
+        }
+        if ($name === null && $fieldSpec === '' && $sqlExpression === '') {
+            // DataObjectSchema needs to be able to make a singleton with no args.
+            // This means we need these to be able to be empty....
+            // In that case, we can just skip all the fancy stuff.
+            // Don't use the parent constructor because it calls setValue() even though we have no value.
+            return;
+        } elseif ($fieldSpec === '' || $sqlExpression === '') {
+            throw new InvalidArgumentException('$fieldSpec and $sqlExpression must not be empty');
+        }
+        $this->sqlExpression = $sqlExpression;
+        $this->generationType = $generationType;
+        $this->childField = DBField::create_field($fieldSpec, null, $name);
+        $this->validateChildFieldClass();
+        $this->setFailover($this->childField);
+        parent::__construct($name, []);
+    }
+
+    public function getChildField(): DBField
+    {
+        return $this->childField;
+    }
+
+    public function requireField(): void
+    {
+        $spec = $this->getChildField()->getFieldSpec();
+        if (is_string($spec)) {
+            $defaultValue = $this->getChildField()->getDefaultValue();
+            $spec = DB::get_schema()->makeGenerated(
+                $spec,
+                ['default' => $defaultValue],
+                $this->sqlExpression,
+                $this->generationType
+            );
+        } else {
+            $spec['generated'] = [
+                'type' => $this->generationType,
+                'expression' => $this->sqlExpression,
+            ];
+        }
+        DB::require_field($this->getTable(), $this->getName(), $spec);
+    }
+
+    public function scaffoldFormField(?string $title = null, array $params = []): ?FormField
+    {
+        return $this->getChildField()->scaffoldFormField($title, $params)->performReadonlyTransformation();
+    }
+
+    public function scaffoldSearchField(?string $title = null): ?FormField
+    {
+        return $this->getChildField()->scaffoldSearchField($title);
+    }
+
+    public function defaultSearchFilter(?string $name = null): SearchFilter
+    {
+        return $this->getChildField()->defaultSearchFilter($name);
+    }
+
+    public function getIndexSpecs(): ?array
+    {
+        return $this->getChildField()->getIndexSpecs();
+    }
+
+    public function getIndexType()
+    {
+        return $this->getChildField()->getIndexType();
+    }
+
+    public function getSchemaValue(): mixed
+    {
+        return $this->getChildField()->getSchemaValue();
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->getChildField()->getValue();
+    }
+
+    public function getArrayValue()
+    {
+        return $this->getChildField()->getArrayValue();
+    }
+
+    public function getDefaultValue(): mixed
+    {
+        return $this->getChildField()->getDefaultValue();
+    }
+
+    public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
+    {
+        $this->getChildField()->setValue($value, $record, $markChanged);
+        return parent::setValue($value, $record, $markChanged);
+    }
+
+    public function setArrayValue($value): static
+    {
+        $this->getChildField()->setArrayValue($value);
+        return parent::setArrayValue($value);
+    }
+
+    public function setDefaultValue(mixed $defaultValue): static
+    {
+        $this->getChildField()->setDefaultValue($defaultValue);
+        return parent::setDefaultValue($defaultValue);
+    }
+
+    public function setName(string $name): static
+    {
+        $this->getChildField()->setName($name);
+        return parent::setName($name);
+    }
+
+    public function setTable(string $tableName): static
+    {
+        $this->getChildField()->setTable($tableName);
+        return parent::setTable($tableName);
+    }
+
+    public function hasValue(string $field, array $arguments = [], bool $cache = true): bool
+    {
+        return $this->getChildField()->hasValue($field, $arguments, $cache);
+    }
+
+    public function nullValue(): mixed
+    {
+        return $this->getChildField()->nullValue();
+    }
+
+    public function exists(): bool
+    {
+        return $this->getChildField()->exists();
+    }
+
+    public function obj(string $fieldName, array $arguments = [], bool $cache = false): ?object
+    {
+        return $this->getChildField()->obj($fieldName, $arguments, $cache);
+    }
+
+    public function castingHelper(string $field): ?string
+    {
+        return $this->getChildField()->castingHelper($field);
+    }
+
+    public function __toString(): string
+    {
+        return $this->getChildField()->__toString();
+    }
+
+    public function forTemplate(): string
+    {
+        return $this->getChildField()->forTemplate();
+    }
+
+    public function HTMLATT(): string
+    {
+        return $this->getChildField()->HTMLATT();
+    }
+
+    public function URLATT(): string
+    {
+        return $this->getChildField()->URLATT();
+    }
+
+    public function RAWURLATT(): string
+    {
+        return $this->getChildField()->RAWURLATT();
+    }
+
+    public function ATT(): string
+    {
+        return $this->getChildField()->ATT();
+    }
+
+    public function RAW(): mixed
+    {
+        return $this->getChildField()->RAW();
+    }
+
+    public function JS(): string
+    {
+        return $this->getChildField()->JS();
+    }
+
+    public function JSON(): string
+    {
+        return $this->getChildField()->JSON();
+    }
+
+    public function HTML(): string
+    {
+        return $this->getChildField()->HTML();
+    }
+
+    public function XML(): string
+    {
+        return $this->getChildField()->XML();
+    }
+
+    public function CDATA(): string
+    {
+        return $this->getChildField()->CDATA();
+    }
+
+    public function debug(): string
+    {
+        return $this->getChildField()->debug();
+    }
+
+    public function scalarValueOnly(): bool
+    {
+        return $this->getChildField()->scalarValueOnly();
+    }
+
+    public function renderWith($template, ModelData|array $customFields = []): DBHTMLText
+    {
+        return $this->getChildField()->renderWith($template, $customFields);
+    }
+
+    public function validate(): ValidationResult
+    {
+        return $this->getChildField()->validate();
+    }
+
+    public function writeToManipulation(array &$manipulation): void
+    {
+        // no-op - generated columns can't be updated manually.
+    }
+
+    private function validateChildFieldClass(): void
+    {
+        foreach (static::config()->get('invalid_child_field_types') as $invalidClass) {
+            if (is_a($this->childField, $invalidClass)) {
+                $class = get_class($this->childField);
+                throw new InvalidArgumentException("Cannot create a generated field based on class '$class'.");
+            }
+        }
+        if (!$this->childField->hasMethod('getFieldSpec')) {
+            $class = get_class($this->childField);
+            throw new InvalidArgumentException("Cannot create a generated field based on class '$class' - it needs a 'getFieldSpec' method.");
+        }
+    }
+}

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -63,6 +63,14 @@ class DBInt extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = [
             'datatype' => 'int',
             'precision' => 11,
@@ -70,8 +78,7 @@ class DBInt extends DBField
             'default' => $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
-        $values = ['type' => 'int', 'parts' => $parts];
-        DB::require_field($this->tableName, $this->name, $values);
+        return ['type' => 'int', 'parts' => $parts];
     }
 
     public function Nice(): string

--- a/src/ORM/FieldType/DBMultiEnum.php
+++ b/src/ORM/FieldType/DBMultiEnum.php
@@ -9,7 +9,6 @@ use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
 use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\MultiSelectField;
 use SilverStripe\ORM\Connect\MySQLDatabase;
-use SilverStripe\ORM\DB;
 
 /**
  * Represents an multi-select enumeration field.
@@ -59,25 +58,17 @@ class DBMultiEnum extends DBEnum
         return $value;
     }
 
-    public function requireField(): void
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
     {
-        $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
-        $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
-        $values = [
-            'type' => 'set',
-            'parts' => [
-                'enums' => $this->enum,
-                'character set' => $charset,
-                'collate' => $collation,
-                'default' => $this->default,
-                'table' => $this->tableName,
-                'arrayValue' => $this->arrayValue,
-            ],
-        ];
-
-        DB::require_field($this->tableName, $this->name, $values);
+        $schema = parent::getFieldSpec();
+        $schema['type'] = 'set';
+        $schema['parts']['enums'] = $this->enum;
+        unset($schema['parts']['datatype']);
+        return $schema;
     }
-
 
     /**
      * Return a form field suitable for editing this field

--- a/src/ORM/FieldType/DBPrimaryKey.php
+++ b/src/ORM/FieldType/DBPrimaryKey.php
@@ -38,10 +38,12 @@ class DBPrimaryKey extends DBInt
         return $this->autoIncrement;
     }
 
-    public function requireField(): void
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
     {
-        $spec = DB::get_schema()->IdColumn(false, $this->getAutoIncrement());
-        DB::require_field($this->getTable(), $this->getName(), $spec);
+        return DB::get_schema()->IdColumn(false, $this->getAutoIncrement());
     }
 
     public function scaffoldFormField(?string $title = null, array $params = []): ?FormField

--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -44,6 +44,14 @@ class DBText extends DBString
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
 
@@ -55,12 +63,10 @@ class DBText extends DBString
             'arrayValue' => $this->arrayValue
         ];
 
-        $values = [
+        return [
             'type' => 'text',
             'parts' => $parts
         ];
-
-        DB::require_field($this->tableName, $this->name, $values);
     }
 
     /**

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -128,15 +128,22 @@ class DBTime extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = [
             'datatype' => 'time',
             'arrayValue' => $this->arrayValue
         ];
-        $values = [
+        return [
             'type' => 'time',
             'parts' => $parts
         ];
-        DB::require_field($this->tableName, $this->name, $values);
     }
 
     public function scaffoldFormField(?string $title = null, array $params = []): ?FormField

--- a/src/ORM/FieldType/DBVarchar.php
+++ b/src/ORM/FieldType/DBVarchar.php
@@ -66,6 +66,14 @@ class DBVarchar extends DBString
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
 
@@ -77,12 +85,10 @@ class DBVarchar extends DBString
             'arrayValue' => $this->arrayValue
         ];
 
-        $values = [
+        return [
             'type' => 'varchar',
             'parts' => $parts
         ];
-
-        DB::require_field($this->tableName, $this->name, $values);
     }
 
     /**

--- a/src/ORM/FieldType/DBYear.php
+++ b/src/ORM/FieldType/DBYear.php
@@ -28,9 +28,16 @@ class DBYear extends DBField
 
     public function requireField(): void
     {
+        DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
+    }
+
+    /**
+     * Get the specifications which will be used to generate this column in the database.
+     */
+    public function getFieldSpec(): string|array
+    {
         $parts = ['datatype' => 'year', 'precision' => 4, 'arrayValue' => $this->arrayValue];
-        $values = ['type' => 'year', 'parts' => $parts];
-        DB::require_field($this->tableName, $this->name, $values);
+        return ['type' => 'year', 'parts' => $parts];
     }
 
     public function scaffoldFormField(?string $title = null, array $params = []): ?FormField

--- a/tests/php/Forms/GridField/GridFieldDataColumnsTest.php
+++ b/tests/php/Forms/GridField/GridFieldDataColumnsTest.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\GridField\GridFieldConfig_Base;
 use SilverStripe\Forms\Tests\GridField\GridFieldDataColumnsTest\TestStatusFlagsObject;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Model\ArrayData;
+use SilverStripe\ORM\FieldType\DBField;
 use stdClass;
 
 class GridFieldDataColumnsTest extends SapphireTest
@@ -89,6 +90,61 @@ class GridFieldDataColumnsTest extends SapphireTest
         );
 
         $component->getDisplayFields($gridField);
+    }
+
+    public static function provideGetColumnContent(): array
+    {
+        return [
+            [
+                'fieldSpec' => 'Varchar(255)',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '&lt;a href=&quot;https://example.com&quot;&gt;text here&lt;a&gt;',
+            ],
+            [
+                'fieldSpec' => 'Text',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '&lt;a href=&quot;https://example.com&quot;&gt;text here&lt;a&gt;',
+            ],
+            [
+                'fieldSpec' => 'HTMLVarchar',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '<a href="https://example.com">text here<a>',
+            ],
+            [
+                'fieldSpec' => 'HTMLText',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '<a href="https://example.com">text here<a>',
+            ],
+            [
+                'fieldSpec' => 'HTMLFragment',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '<a href="https://example.com">text here<a>',
+            ],
+            [
+                'fieldSpec' => 'Generated("Varchar(255)", "anything")',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '&lt;a href=&quot;https://example.com&quot;&gt;text here&lt;a&gt;',
+            ],
+            [
+                'fieldSpec' => 'Generated("HTMLText", "anything")',
+                'value' => '<a href="https://example.com">text here<a>',
+                'expected' => '<a href="https://example.com">text here<a>',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetColumnContent')]
+    public function testGetColumnContent(string $fieldSpec, string $value, string $expected): void
+    {
+        $field = DBField::create_field($fieldSpec, $value);
+        $record = new ArrayData(['MyField' => $field]);
+        $component = new GridFieldDataColumns();
+        $component->setDisplayFields(['MyField']);
+        $config = new GridFieldConfig_Base();
+        $config->addComponent($component);
+        $gridField = new GridField('dummy', 'dummy', new ArrayList([$record]), $config);
+
+        $this->assertSame($expected, $component->getColumnContent($gridField, $record, 'MyField'));
     }
 
     public static function provideGetColumnContentHasStatusFlags(): array

--- a/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
@@ -149,7 +149,7 @@ class GridFieldPrintButtonTest extends SapphireTest
                 'useGridFieldDataColumns' => true,
                 'expected' => 'before&amp;lt;script&amp;gt;alert("hehehe");&amp;lt;/script&amp;gt;after&amp;amp;',
             ],
-            'raw string pre-escaped with datacolumns' => [
+            'raw string as HTML with datacolumns' => [
                 'value' => 'before<script>alert("hehehe");</script>after&amp;',
                 'useGridFieldDataColumns' => true,
                 'expected' => 'beforealert("hehehe");after&amp;amp;',
@@ -230,6 +230,46 @@ class GridFieldPrintButtonTest extends SapphireTest
 
         $this->assertCount(1, $cellContent);
         $this->assertSame("<td>{$expected}</td>", $cellContent[0]->asXML());
+    }
+
+    public static function provideHandlePrintEscapingWithGeneratedColumns(): array
+    {
+        // This has to be separate from provideHandlePrintEscaping because we can't instantiate a
+        // DBGenerated in a provider because it uses injector to create the child field
+        return [
+            'non-HTML-field' => [
+                'fieldSpec' => 'Generated("Varchar(255)", "anything")',
+                'value' => 'before<script>alert("hehehe");</script>after&amp;',
+                'useGridFieldDataColumns' => false,
+                'expected' => 'before&lt;script&gt;alert("hehehe");&lt;/script&gt;after&amp;amp;',
+            ],
+            'HTML-field' => [
+                'fieldSpec' => 'Generated("HTMLText", "anything")',
+                'value' => 'before<script>alert("hehehe");</script>after&amp;',
+                'useGridFieldDataColumns' => false,
+                'expected' => 'before&lt;script&gt;alert("hehehe");&lt;/script&gt;after&amp;amp;',
+            ],
+            // With data columns component
+            'non-HTML-field with datacolumns' => [
+                'fieldSpec' => 'Generated("Varchar(255)", "anything")',
+                'value' => 'before<script>alert("hehehe");</script>after&amp;',
+                'useGridFieldDataColumns' => true,
+                'expected' => 'beforealert("hehehe");after&amp;amp;',
+            ],
+            'HTML-field with datacolumns' => [
+                'fieldSpec' => 'Generated("HTMLText", "anything")',
+                'value' => 'before<script>alert("hehehe");</script>after&amp;',
+                'useGridFieldDataColumns' => true,
+                'expected' => 'beforealert("hehehe");after&amp;amp;',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideHandlePrintEscapingWithGeneratedColumns')]
+    public function testHandlePrintEscapingWithGeneratedColumns(string $fieldSpec, string $value, bool $useGridFieldDataColumns, string $expected): void
+    {
+        $field = DBField::create_field($fieldSpec, $value);
+        $this->testHandlePrintEscaping($field, $useGridFieldDataColumns, $expected);
     }
 
     public function testGetPrintColumnsForGridFieldThrowsException()

--- a/tests/php/ORM/DBFieldTest.php
+++ b/tests/php/ORM/DBFieldTest.php
@@ -58,6 +58,7 @@ use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
 use SilverStripe\ORM\FieldType\DBClassNameVarchar;
 use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
 use SilverStripe\Core\Validation\FieldValidation\NumericNonStringFieldValidator;
+use SilverStripe\ORM\FieldType\DBGenerated;
 
 /**
  * Tests for DBField objects.
@@ -439,6 +440,10 @@ class DBFieldTest extends SapphireTest
             if (!str_starts_with($class, 'SilverStripe\ORM\FieldType')) {
                 continue;
             }
+            if (is_a($class, DBGenerated::class, true)) {
+                // This is a special case and will be tested explicitly in its own test class
+                continue;
+            }
             $reflector = new ReflectionClass($class);
             if ($reflector->isAbstract()) {
                 continue;
@@ -564,6 +569,10 @@ class DBFieldTest extends SapphireTest
                 continue;
             }
             if (!str_starts_with($class, 'SilverStripe\ORM\FieldType')) {
+                continue;
+            }
+            if (is_a($class, DBGenerated::class, true)) {
+                // This is a special case and will be tested explicitly in its own test class
                 continue;
             }
             $reflector = new ReflectionClass($class);

--- a/tests/php/ORM/DBGeneratedTest.php
+++ b/tests/php/ORM/DBGeneratedTest.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+use SilverStripe\Core\Injector\InjectorNotFoundException;
+use SilverStripe\ORM\FieldType;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBGenerated;
+use SilverStripe\ORM\Tests\DBGeneratedTest\TestDBField;
+
+class DBGeneratedTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    public static function provideGetChildField(): array
+    {
+        return [
+            'BigInt' => [
+                'fieldSpec' => 'BigInt',
+                'expectedChildClass' => FieldType\DBBigInt::class,
+            ],
+            'Boolean' => [
+                'fieldSpec' => 'Boolean',
+                'expectedChildClass' => FieldType\DBBoolean::class,
+            ],
+            'Currency' => [
+                'fieldSpec' => 'Currency',
+                'expectedChildClass' => FieldType\DBCurrency::class,
+            ],
+            'Date' => [
+                'fieldSpec' => 'Date',
+                'expectedChildClass' => FieldType\DBDate::class,
+            ],
+            'Datetime' => [
+                'fieldSpec' => 'Datetime',
+                'expectedChildClass' => FieldType\DBDatetime::class,
+            ],
+            'Decimal' => [
+                'fieldSpec' => 'Decimal',
+                'expectedChildClass' => FieldType\DBDecimal::class,
+            ],
+            'Double' => [
+                'fieldSpec' => 'Double',
+                'expectedChildClass' => FieldType\DBDouble::class,
+            ],
+            'Email' => [
+                'fieldSpec' => 'Email',
+                'expectedChildClass' => FieldType\DBEmail::class,
+            ],
+            'Enum' => [
+                'fieldSpec' => 'Enum',
+                'expectedChildClass' => FieldType\DBEnum::class,
+            ],
+            'Float' => [
+                'fieldSpec' => 'Float',
+                'expectedChildClass' => FieldType\DBFloat::class,
+            ],
+            'HTMLFragment' => [
+                'fieldSpec' => 'HTMLFragment',
+                'expectedChildClass' => FieldType\DBHTMLText::class,
+            ],
+            'HTMLText' => [
+                'fieldSpec' => 'HTMLText',
+                'expectedChildClass' => FieldType\DBHTMLText::class,
+            ],
+            'HTMLVarchar' => [
+                'fieldSpec' => 'HTMLVarchar',
+                'expectedChildClass' => FieldType\DBHTMLVarchar::class,
+            ],
+            'Int' => [
+                'fieldSpec' => 'Int',
+                'expectedChildClass' => FieldType\DBInt::class,
+            ],
+            'IP' => [
+                'fieldSpec' => 'IP',
+                'expectedChildClass' => FieldType\DBIp::class,
+            ],
+            'Locale' => [
+                'fieldSpec' => 'Locale',
+                'expectedChildClass' => FieldType\DBLocale::class,
+            ],
+            'MultiEnum' => [
+                'fieldSpec' => 'MultiEnum',
+                'expectedChildClass' => FieldType\DBMultiEnum::class,
+            ],
+            'Percentage' => [
+                'fieldSpec' => 'Percentage',
+                'expectedChildClass' => FieldType\DBPercentage::class,
+            ],
+            'Text' => [
+                'fieldSpec' => 'Text',
+                'expectedChildClass' => FieldType\DBText::class,
+            ],
+            'Time' => [
+                'fieldSpec' => 'Time',
+                'expectedChildClass' => FieldType\DBTime::class,
+            ],
+            'URL' => [
+                'fieldSpec' => 'URL',
+                'expectedChildClass' => FieldType\DBUrl::class,
+            ],
+            'Varchar' => [
+                'fieldSpec' => 'Varchar',
+                'expectedChildClass' => FieldType\DBVarchar::class,
+            ],
+            'Year' => [
+                'fieldSpec' => 'Year',
+                'expectedChildClass' => FieldType\DBYear::class,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetChildField')]
+    public function testGetChildField(string $fieldSpec, string $expectedChildClass): void
+    {
+        $field = new DBGenerated('MyField', $fieldSpec, 'any expression');
+        // Don't use assertInstanceOf because we want to check the exact class, not including subclasses
+        $this->assertSame($expectedChildClass, get_class($field->getChildField()));
+    }
+
+    public static function provideInvalidFieldSpec(): array
+    {
+        return [
+            [
+                'fieldSpec' => 'Money',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBMoney::class . '\'.',
+            ],
+            [
+                'fieldSpec' => 'ForeignKey',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBForeignKey::class . '\'.',
+            ],
+            [
+                'fieldSpec' => 'PolymorphicForeignKey',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBPolymorphicForeignKey::class . '\'.',
+            ],
+            [
+                'fieldSpec' => 'PolymorphicRelationAwareForeignKey',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBPolymorphicRelationAwareForeignKey::class . '\'.',
+            ],
+            [
+                'fieldSpec' => 'PrimaryKey',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBPrimaryKey::class . '\'.',
+            ],
+            [
+                'fieldSpec' => 'DBClassName',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBClassName::class . '\'.',
+            ],
+            [
+                'fieldSpec' => 'DBClassNameVarchar',
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . FieldType\DBClassNameVarchar::class . '\'.',
+            ],
+            [
+                'fieldSpec' => TestDBField::class,
+                'expectedExceptionClass' => InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'Cannot create a generated field based on class \'' . TestDBField::class . '\' - it needs a \'getFieldSpec\' method.',
+            ],
+            [
+                'fieldSpec' => 'SomeRandomNonsense',
+                'expectedExceptionClass' => InjectorNotFoundException::class,
+                'expectedExceptionMessage' => 'Class SomeRandomNonsense does not exist',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidFieldSpec')]
+    public function testInvalidFieldSpec(string $fieldSpec, string $expectedExceptionClass, string $expectedExceptionMessage): void
+    {
+        $this->expectException($expectedExceptionClass);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        new DBGenerated('MyField', $fieldSpec, 'any expression');
+    }
+
+    public static function provideAdvancedFieldSpec(): array
+    {
+        // Note that this is not exhaustive - we don't need to test that all constructors
+        // for all DBField types use the arguments in the expected ways.
+        // This just tests that in general the fieldspec is correctly passed through and
+        // sets options in the underlying data type.
+        return [
+            [
+                'fieldSpec' => 'Varchar(123, ["nullifyEmpty" => false])',
+                'methodCallsAndResults' => [
+                    'getSize' => 123,
+                    'getNullifyEmpty' => false,
+                ],
+            ],
+            [
+                'fieldSpec' => 'Decimal(25, 30)',
+                'methodCallsAndResults' => [
+                    'getWholeSize' => 25,
+                    'getDecimalSize' => 30,
+                ],
+            ],
+            [
+                'fieldSpec' => 'Enum(["val1", "val2", "val3"])',
+                'methodCallsAndResults' => [
+                    'getEnum' => ['val1', 'val2', 'val3'],
+                ],
+            ],
+            [
+                'fieldSpec' => 'HTMLText(["whitelist" => "one,two,three"])',
+                'methodCallsAndResults' => [
+                    'getWhitelist' => ['one', 'two', 'three'],
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideAdvancedFieldSpec')]
+    public function testAdvancedFieldSpec(string $fieldSpec, array $methodCallsAndResults): void
+    {
+        $field = new DBGenerated('MyField', $fieldSpec, 'any expression');
+        $childField = $field->getChildField();
+        foreach ($methodCallsAndResults as $method => $expected) {
+            $this->assertSame($expected, $childField->$method());
+        }
+    }
+
+    public static function provideMethodCalls(): array
+    {
+        $scenarios = static::provideGetChildField();
+        foreach ($scenarios as &$scenario) {
+            unset($scenario['expectedChildClass']);
+        }
+        return $scenarios;
+    }
+
+    /**
+     * Tests that public methods (if explicitly defined on DBField) get passed through
+     * to the underlying data representation where appropriate.
+     * Note that we use fieldspecs for all valid DBField instances to ensure there aren't
+     * any unexpected cases.
+     */
+    #[DataProvider('provideMethodCalls')]
+    public function testMethodCalls(string $fieldSpec): void
+    {
+        // Prep field
+        $field = new DBGenerated('MyField', $fieldSpec, 'any expression');
+        $field->setValue(123);
+        $field->setDefaultValue(456);
+        $field->setTable('mytable');
+        $field->setArrayValue(['a', 'b', 'c']);
+        $field->setIndexType(FieldType\DBIndexable::TYPE_INDEX);
+        $childField = $field->getChildField();
+
+        // Find methods
+        $methods = get_class_methods(DBField::class);
+        // Skip some methods explicitly
+        $methods = array_diff($methods, [
+            'addToQuery',
+            'getValueForValidation',
+            'getOptions',
+            'prepValueForDB',
+            'requireField',
+            'saveInto',
+            'uninherited',
+            'validate',
+            'writeToManipulation',
+        ]);
+
+        $reflectionGeneratedColumn = new ReflectionClass(DBField::class);
+        foreach ($methods as $method) {
+            // Magic methods don't count
+            if (str_starts_with($method, '__')) {
+                continue;
+            }
+            // Skip setters
+            if (str_starts_with($method, 'set')) {
+                continue;
+            }
+            // Skip static or non-public methods which don't pass through
+            $reflectionMethod = $reflectionGeneratedColumn->getMethod($method);
+            if ($reflectionMethod->isStatic() || !$reflectionMethod->isPublic()) {
+                continue;
+            }
+            // Skip any inherited methods
+            if (!in_array($reflectionMethod->getDeclaringClass()->getName(), [DBField::class])) {
+                continue;
+            }
+
+            switch ($method) {
+                case 'defaultSearchFilter':
+                    $childFilter = $childField->$method();
+                    $mainFilter = $field->$method();
+                    $this->assertSame(get_class($childFilter), get_class($mainFilter));
+                    break;
+                case 'scaffoldSearchField':
+                    $childFormField = $childField->$method();
+                    $mainFormField = $field->$method();
+                    $this->assertSame(get_class($childFormField), get_class($mainFormField));
+                    $this->assertSame($childFormField->title(), $mainFormField->title());
+                    break;
+                case 'scaffoldFormField':
+                    $childFormField = $childField->$method();
+                    $mainFormField = $field->$method();
+                    // note the readonly transformation
+                    $this->assertSame(get_class($childFormField->performReadonlyTransformation()), get_class($mainFormField));
+                    $this->assertSame($childFormField->title(), $mainFormField->title());
+                    break;
+                default:
+                    $this->assertSame($childField->$method(), $field->$method(), "testing $method");
+            }
+        }
+    }
+
+    public function testFailover()
+    {
+        // this is intentionally not exhaustive - we're just making sure that in general methods failover to the child class.
+        $field = new DBGenerated('MyField', 'HTMLText', 'any expression');
+        $this->assertSame($field->getChildField(), $field->getFailover());
+        $this->assertSame($field->getChildField()->LowerCase(), $field->LowerCase());
+    }
+
+    public function testForTemplate()
+    {
+        $field = new DBGenerated('MyField', 'HTMLText', 'any expression');
+        $field->setValue('<div><p><a href="[sitetree_link id=123]">text here</a></p></div>');
+        $this->assertSame($field->getChildField()->forTemplate(), $field->forTemplate());
+    }
+
+    public function testCastingHelper()
+    {
+        $field = new DBGenerated('MyField', 'HTMLText', 'any expression');
+        $this->assertSame($field->getChildField()->castingHelper('LowerCase'), $field->castingHelper('LowerCase'));
+    }
+
+    public function testObj()
+    {
+        $field = new DBGenerated('MyField', 'HTMLText', 'any expression');
+        $this->assertSame($field->getChildField()->obj('LowerCase')?->getValue(), $field->obj('LowerCase')?->getValue());
+    }
+
+    public function testHasValue()
+    {
+        $field = new DBGenerated('MyField', 'HTMLText', 'any expression');
+        $this->assertSame($field->getChildField()->hasValue('LowerCase'), $field->hasValue('LowerCase'));
+    }
+}

--- a/tests/php/ORM/DBGeneratedTest/TestDBField.php
+++ b/tests/php/ORM/DBGeneratedTest/TestDBField.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DBGeneratedTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\FieldType\DBField;
+
+class TestDBField extends DBField implements TestOnly
+{
+    public function requireField(): void
+    {
+        // no-op
+    }
+}

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -39,6 +39,8 @@ use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\FieldType\DBInt;
 use SilverStripe\ORM\Filters\WithinRangeFilter;
+use SilverStripe\ORM\Tests\DataObjectTest\TestGeneratedColumns;
+use SilverStripe\ORM\Tests\DataObjectTest\TestGeneratedColumnsManipulationExtension;
 use stdClass;
 
 class DataObjectTest extends SapphireTest
@@ -82,6 +84,7 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\InjectedDataObject::class,
         DataObjectTest\SettersAndGetters::class,
         DataObjectTest\UniqueIndexObject::class,
+        DataObjectTest\TestGeneratedColumns::class,
     ];
 
     protected function setUp(): void
@@ -3091,6 +3094,40 @@ class DataObjectTest extends SapphireTest
         $record2->write();
     }
 
+    public static function provideExceptionForSetValueOnGeneratedColumn(): array
+    {
+        return [
+            // Check both STORED and VIRTUAL columns behave the same way
+            ['columnName' => 'GeneratedField1'],
+            ['columnName' => 'GeneratedField2'],
+        ];
+    }
+
+    #[DataProvider('provideExceptionForSetValueOnGeneratedColumn')]
+    public function testExceptionForSetValueOnGeneratedColumn(string $columnName): void
+    {
+        if (preg_match('/mariadb/i', DB::get_conn()->getVersion())) {
+            $this->markTestSkipped('This test is only relevant for MySQL specifically.');
+        }
+        $record = new TestGeneratedColumns();
+        // Expect no exception on first write
+        $record->write();
+        // Expect no exception on normal edit
+        $record->$columnName = 'some value';
+        $record->write();
+
+        // Add extension and work around issue with extension instances not being static
+        TestGeneratedColumns::add_extension(TestGeneratedColumnsManipulationExtension::class);
+        TestGeneratedColumnsManipulationExtension::setUpdateColumn($columnName);
+        $record = TestGeneratedColumns::get()->byID($record->ID);
+
+        // Expect an exception if something is manually trying to update the manipulation (e.g. versioned)
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Cannot set a value for generated field "' . $record->fieldLabel($columnName) . '"');
+        $record->$columnName = 'new value';
+        $record->write();
+    }
+
     public static function provideProvideI18nEntities(): array
     {
         return [
@@ -3185,5 +3222,30 @@ class DataObjectTest extends SapphireTest
         $this->assertSame($cachedTeamComment2, DataObjectTest\TeamComment::get()->setUseCache(true)->first());
         $queryCounter->stopCounting();
         $this->assertSame(0, $queryCounter->getCount());
+    }
+
+    public function testFetchGeneratedColumnAfterWrite(): void
+    {
+        $record = new DataObjectTest\TestGeneratedColumns(['BaseField' => 'Some Value']);
+        $record->write();
+        $this->assertSame('Some Value_etc', $record->GeneratedField1);
+        $this->assertSame('Some Value_etc', $record->GeneratedField2);
+
+        $record->BaseField = 'changed';
+        $record->write();
+        $this->assertSame('changed_etc', $record->GeneratedField1);
+        $this->assertSame('changed_etc', $record->GeneratedField2);
+
+        DataObjectTest\TestGeneratedColumns::config()->set('skip_fetch_generated_columns_after_write', true);
+        $record->BaseField = 'new value';
+        $record->write();
+        $this->assertSame('changed_etc', $record->GeneratedField1);
+        $this->assertSame('changed_etc', $record->GeneratedField2);
+
+        DataObjectTest\TestGeneratedColumns::config()->set('skip_fetch_generated_columns_after_write', ['GeneratedField1']);
+        $record->BaseField = 'another value';
+        $record->write();
+        $this->assertSame('changed_etc', $record->GeneratedField1);
+        $this->assertSame('another value_etc', $record->GeneratedField2);
     }
 }

--- a/tests/php/ORM/DataObjectTest/TestGeneratedColumns.php
+++ b/tests/php/ORM/DataObjectTest/TestGeneratedColumns.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class TestGeneratedColumns extends DataObject implements TestOnly
+{
+    private static string $table_name = 'DataObjectTest_TestGeneratedColumns';
+
+    private static array $db = [
+        'BaseField' => 'Varchar(255)',
+        'GeneratedField1' => 'Generated("Varchar(255)", "CONCAT(\\"BaseField\\", \'_etc\')", "VIRTUAL")',
+        'GeneratedField2' => 'Generated("Varchar(255)", "CONCAT(\\"BaseField\\", \'_etc\')", "STORED")',
+    ];
+}

--- a/tests/php/ORM/DataObjectTest/TestGeneratedColumnsManipulationExtension.php
+++ b/tests/php/ORM/DataObjectTest/TestGeneratedColumnsManipulationExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class TestGeneratedColumnsManipulationExtension extends Extension implements TestOnly
+{
+    /**
+     * @internal
+     */
+    private static string $updateColumnName;
+
+    public static function setUpdateColumn($columnName): void
+    {
+        TestGeneratedColumnsManipulationExtension::$updateColumnName = $columnName;
+    }
+
+    protected function augmentWrite(array &$manipulation): void
+    {
+        $manipulation['DataObjectTest_TestGeneratedColumns']['fields'][TestGeneratedColumnsManipulationExtension::$updateColumnName] = 'blah';
+    }
+}

--- a/tests/php/ORM/MySQLSchemaManagerTest.php
+++ b/tests/php/ORM/MySQLSchemaManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\Connect\MySQLSchemaManager;
 use SilverStripe\Dev\SapphireTest;
@@ -206,4 +208,131 @@ class MySQLSchemaManagerTest extends SapphireTest
             'mariadb IdColumn forced off has no width'
         );
     }
+
+    public static function provideNeedRebuildColumn(): array
+    {
+        return [
+            'normal column matching' => [
+                'existingSpec' => 'tinyint 1 unsigned not null default 0',
+                'newSpec' => 'tinyint 1 unsigned not null default 0',
+                'expected' => false,
+            ],
+            'normal column not matching' => [
+                'existingSpec' => 'varchar 255 default \'oogabooga\'',
+                'newSpec' => 'tinyint 1 unsigned not null default 0',
+                'expected' => false,
+            ],
+            'generated column matching' => [
+                'existingSpec' => 'double AS ("Price" * 0.25) STORED',
+                'newSpec' => 'double AS ("Price" * 0.25) STORED',
+                'expected' => false,
+            ],
+            'generated column different expression' => [
+                'existingSpec' => 'double AS ("Price" * "Discount") STORED',
+                'newSpec' => 'double AS ("Price" * 0.25) STORED',
+                'expected' => false,
+            ],
+            'generated column different datatype' => [
+                'existingSpec' => 'varchar 255 AS ("Price" * 0.25) STORED',
+                'newSpec' => 'double AS ("Price" * 0.25) STORED',
+                'expected' => false,
+            ],
+            'generated column stored to virtual' => [
+                'existingSpec' => 'double AS ("Price" * 0.25) STORED',
+                'newSpec' => 'double AS ("Price" * 0.25) VIRTUAL',
+                'expected' => true,
+            ],
+            'generated column virtual to stored' => [
+                'existingSpec' => 'double AS ("Price" * 0.25) VIRTUAL',
+                'newSpec' => 'double AS ("Price" * 0.25) STORED',
+                'expected' => true,
+            ],
+            'generated column stored to non-generated' => [
+                'existingSpec' => 'double AS ("Price" * 0.25) STORED',
+                'newSpec' => 'double',
+                'expected' => false,
+            ],
+            'generated column virtual to non-generated' => [
+                'existingSpec' => 'double AS ("Price" * 0.25) VIRTUAL',
+                'newSpec' => 'double',
+                'expected' => true,
+            ],
+            'normal column to stored generated' => [
+                'existingSpec' => 'varchar 255 default \'oogabooga\'',
+                'newSpec' => 'varchar 255 AS (CONCAT("FirstName", "LastName")) STORED',
+                'expected' => false,
+            ],
+            'normal column to virtual generated' => [
+                'existingSpec' => 'varchar 255 default \'oogabooga\'',
+                'newSpec' => 'varchar 255 AS (CONCAT("FirstName", "LastName")) VIRTUAL',
+                'expected' => true,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideNeedRebuildColumn')]
+    public function testNeedRebuildColumn(string $existingSpec, string $newSpec, bool $expected): void
+    {
+        $manager = new MySQLSchemaManager();
+        $reflectionMethod = new ReflectionMethod($manager, 'needRebuildColumn');
+        $this->assertSame($expected, $reflectionMethod->invoke($manager, $existingSpec, $newSpec));
+    }
+
+    public static function provideNormaliseGeneratedColumnExpression(): array
+    {
+        return [
+            'expression with no thrills' => [
+                'expression' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'backtick quotes' => [
+                'expression' => 'CASE WHEN `Surname` IS NULL THEN \'\' ELSE `Surname` END',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'no quotes at all' => [
+                'expression' => 'CASE WHEN Surname IS NULL THEN \'\' ELSE Surname END',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'explicitcharset before string matches default' => [
+                'expression' => 'CASE WHEN "Surname" IS NULL THEN _utf8mb4\'\' ELSE "Surname" END',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'explicitcharset before string DOESNT match default' => [
+                'expression' => 'CASE WHEN "Surname" IS NULL THEN _utf8\'\' ELSE "Surname" END',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN _utf8 \'\' ELSE "Surname" END',
+            ],
+            'mixed case reserved keywords' => [
+                'expression' => 'CASE when "Surname" IS nUlL THEN \'\' ElSe "Surname" end',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'unnecessary brackets around when' => [
+                'expression' => 'CASE WHEN ("Surname" IS NULL) THEN \'\' ELSE "Surname" END',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'unnecessary brackets around case' => [
+                'expression' => '(CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END)',
+                'expected' => 'CASE WHEN "Surname" IS NULL THEN \'\' ELSE "Surname" END',
+            ],
+            'quotes that actually matter are not touched' => [
+                'expression' => '2 * ((1 + 3) / 4)',
+                'expected' => '2 * ((1 + 3) / 4)',
+            ],
+            // If more scenarios are added above, make sure they're represented in this one below.
+            // This scenario includes all of the above and ensures the logic works as expected in a complex expression.
+            'all the trimmings' => [
+                'expression' => '(trim(concat((2 * ((1 + 3) / 4)), `FirstName`,_utf8mb4\' \',(case when ("Surname" IS null) then _utf8\'\' ELSE Surname end))))',
+                'expected' => 'TRIM(CONCAT((2 * ((1 + 3) / 4)),"FirstName",\' \',CASE WHEN "Surname" IS NULL THEN _utf8 \'\' ELSE "Surname" END))',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideNormaliseGeneratedColumnExpression')]
+    public function testNormaliseGeneratedColumnExpression(string $expression, string $expected): void
+    {
+        $manager = new MySQLSchemaManager();
+        $reflectionMethod = new ReflectionMethod($manager, 'normaliseGeneratedColumnExpression');
+        $this->assertSame($expected, $reflectionMethod->invoke($manager, $expression));
+    }
+
+    // public function testMakeGenerated(): void
 }

--- a/tests/php/ORM/MySQLiConnectorTest.php
+++ b/tests/php/ORM/MySQLiConnectorTest.php
@@ -13,6 +13,7 @@ use SilverStripe\ORM\Tests\MySQLiConnectorTest\MySQLiConnector;
 use SilverStripe\Tests\ORM\Utf8\Utf8TestHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use SilverStripe\ORM\Connect\GeneratedColumnValueException;
 
 #[RequiresPhpExtension('mysqli')]
 class MySQLiConnectorTest extends SapphireTest implements TestOnly
@@ -50,9 +51,9 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
             $this->markTestSkipped("The test only relevant for MySQL - but $config[type] is in use");
         }
 
-        // Build a table for the duplicate entry tests
         DB::get_schema()->schemaUpdate(function () {
             DB::quiet(true);
+            // Build a table for the duplicate entry tests
             DB::require_table(
                 'duplicate_entry_table',
                 [
@@ -68,6 +69,17 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
                 ],
                 options: DataObject::config()->get('create_table_options')
             );
+            // Build a table for the generated column tests
+            DB::require_table(
+                'generated_columns_table',
+                [
+                    'ID' => 'PrimaryKey',
+                    'BaseColumn' => 'Varchar',
+                    'GeneratedColumn1' => 'Generated("Varchar(255)", "CONCAT(\\"BaseColumn\\", \'_etc\')", "VIRTUAL")',
+                    'GeneratedColumn2' => 'Generated("Varchar(255)", "CONCAT(\\"BaseColumn\\", \'_etc\')", "STORED")',
+                ],
+                options: DataObject::config()->get('create_table_options')
+            );
         });
 
         $this->config = $config;
@@ -78,6 +90,7 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
         DB::get_schema()->schemaUpdate(function () {
             DB::quiet(true);
             DB::get_schema()->dontRequireTable('duplicate_entry_table');
+            DB::get_schema()->dontRequireTable('generated_columns_table');
         });
         parent::tearDown();
     }
@@ -174,11 +187,11 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
     public static function provideQueryThrowsException()
     {
         return [
-            [
+            'errors, no exceptions' => [
                 // Uses errors, not exceptions
                 'reportMode' => MYSQLI_REPORT_OFF,
             ],
-            [
+            'always exceptions' => [
                 // Uses exceptions. This is the default since PHP 8.1
                 // See https://www.php.net/manual/en/mysqli-driver.report-mode.php
                 'reportMode' => MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT,
@@ -235,6 +248,39 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
         $this->expectException(DuplicateEntryException::class);
         // Create the duplicate item
         $connector->preparedQuery('INSERT INTO duplicate_entry_table (Title, Name) VALUES (?, ?);', ['My Title', 'My Name']);
+    }
+
+    public static function providePreparedQueryThrowsGeneratedColumnValueException(): array
+    {
+        $baseScenarios = static::provideQueryThrowsException();
+        $scenarios = [];
+        foreach ($baseScenarios as $key => $scenario) {
+            $scenario['columnName'] = 'GeneratedColumn1';
+            $scenarios[$key . ' - virtual column'] = $scenario;
+            $scenario['columnName'] = 'GeneratedColumn2';
+            $scenarios[$key . ' - stored column'] = $scenario;
+        }
+        return $scenarios;
+    }
+
+    #[DataProvider('providePreparedQueryThrowsGeneratedColumnValueException')]
+    public function testPreparedQueryThrowsGeneratedColumnValueException(int $reportMode, string $columnName): void
+    {
+        if (preg_match('/mariadb/i', DB::get_conn()->getVersion())) {
+            $this->markTestSkipped('This test is only relevant for MySQL specifically.');
+        }
+        $connector = $this->getConnector();
+        $driver = new mysqli_driver();
+        $driver->report_mode = $reportMode;
+        $connector = DB::get_conn();
+        // Create the base item
+        $connector->preparedQuery('INSERT INTO generated_columns_table (BaseColumn) VALUES (?);', ['My value']);
+        $this->expectException(GeneratedColumnValueException::class);
+        // Try to update the generated column directly
+        $connector->preparedQuery(
+            'UPDATE generated_columns_table SET ' . $columnName . ' = ? WHERE BaseColumn = ?;',
+            ['My generated value', 'My value']
+        );
     }
 
     #[DataProvider('provideQueryThrowsException')]


### PR DESCRIPTION
This is useful for a few scenarios:
1. You want to sort on a collated set of data (e.g. `summary_fields` using a getter method in PHP which isn't sortable, now you can use a generated column instead of the getter)
2. You have some SQL expression you're filtering or sorting by and want to include an index for it
3. You just generally want the database to handle collations and other similar simple transformations of data instead of doing it in PHP

1 and 2 are pretty good value adds - scenario 2 is the main reason I'm implementing this right now.
Scenario 3 is pretty weak and probably shouldn't be encouraged, but it is an option this change opens up.


## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/693