### PR TITLE
FIX Allow negative keys in `SelectField` implementations

### DIFF
--- a/src/Forms/SelectField.php
+++ b/src/Forms/SelectField.php
@@ -133,7 +133,7 @@ abstract class SelectField extends FormField
      */
     protected function castSubmittedValue(mixed $value): mixed
     {
-        if (!is_string($value) || !is_numeric($value) || !ctype_digit($value)) {
+        if (!is_string($value) || !is_numeric($value)) {
             return $value;
         }
         $sourceValues = $this->getSourceValues();

--- a/tests/php/Forms/SelectFieldTest.php
+++ b/tests/php/Forms/SelectFieldTest.php
@@ -24,6 +24,17 @@ class SelectFieldTest extends SapphireTest
                 'value' => '1',
                 'expected' => 1,
             ],
+            'negative-int-keys' => [
+                'source' => [-1 => 'cat', -2 => 'dog'],
+                'value' => '-2',
+                'expected' => -2,
+            ],
+            'string-negative-int-keys' => [
+                // note that string int are converted to int by PHP
+                'source' => ['-1' => 'cat', '-2' => 'dog'],
+                'value' => '-2',
+                'expected' => -2
+            ],
             'string-keys' => [
                 'source' => ['cat' => 'cat', 'dog' => 'dog'],
                 'value' => 'cat',


### PR DESCRIPTION
`ctype_digit()` doesn't account for negative integers.

If we really want to have the integer check there, we could use `is_int(filter_var($value, FILTER_VALIDATE_INT))` or `preg_match('/^-?\d+$/', $value)`.

I don't think that's strictly necessary because any non-integer numeric values as keys in the source will be implicitly cast to `int` by PHP anyway, so e.g. `1.25` would be implicitly cast to `1` and therefore `(string) $sourceValue === $value` evaluates to `(string)1 === '1.25'` and would return false.

And if PHP _didn't_ do that casting, we would _want_ them to match. Either way it feels like the int check at best isn't needed.

That said, if you want me to add one of the two integer checks I've noted above, let me know which one and I'll add it in where `ctype_digit()` used to be.

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/11777