### PR TITLE
NEW Add additional session handler implementations

### DIFF
--- a/_config/session.yml
+++ b/_config/session.yml
@@ -1,0 +1,26 @@
+---
+Name: session-handlers
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Control\SessionHandler\CacheSessionHandler:
+    constructor:
+      cacheAdapter: '%$Psr\SimpleCache\CacheInterface.session-handler'
+
+  SilverStripe\Core\Cache\RedisCacheFactory:
+    constructor:
+      logger: '%$Psr\Log\LoggerInterface'
+
+  SilverStripe\Core\Cache\MemcachedCacheFactory:
+    constructor:
+      logger: '%$Psr\Log\LoggerInterface'
+
+  Psr\SimpleCache\CacheInterface.session-handler:
+    factory: '`SS_SESSION_CACHE_FACTORY`'
+    constructor:
+      namespace: 'session-handler'
+      defaultLifetime: 0
+      useInjector: true
+      # Use of the DefaultCacheFactory shouldn't be encouraged, but
+      # is technically valid so we have to disable containers to avoid
+      # weird behaviour with versioned, etc.
+      disable-container: true

--- a/_config/session.yml
+++ b/_config/session.yml
@@ -24,3 +24,16 @@ SilverStripe\Core\Injector\Injector:
       # is technically valid so we have to disable containers to avoid
       # weird behaviour with versioned, etc.
       disable-container: true
+
+SilverStripe\Dev\Command\DbBuild:
+  extensions:
+    DbBuildSessionExtension: 'SilverStripe\Control\SessionHandler\DbBuildSessionExtension'
+
+---
+Name: 'session-handlers-test-session'
+Only:
+  moduleexists: 'silverstripe/testsession'
+---
+SilverStripe\TestSession\TestSessionEnvironment:
+  extensions:
+    DbBuildSessionExtension: 'SilverStripe\Control\SessionHandler\DbBuildSessionExtension'

--- a/_config/session.yml
+++ b/_config/session.yml
@@ -4,7 +4,7 @@ Name: session-handlers
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\SessionHandler\CacheSessionHandler:
     constructor:
-      cacheAdapter: '%$Psr\SimpleCache\CacheInterface.session-handler'
+      cache: '%$Psr\SimpleCache\CacheInterface.session-handler'
 
   SilverStripe\Core\Cache\RedisCacheFactory:
     constructor:

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -3,8 +3,10 @@
 namespace SilverStripe\Control;
 
 use BadMethodCallException;
+use SessionHandlerInterface;
 use SilverStripe\Control\SessionHandler\FileSessionHandler;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 
 /**
@@ -157,6 +159,7 @@ class Session
     /**
      * FQCN or injector service name for the session save handler.
      * If null, the save handler defined in `session.save_handler` ini configuration is used.
+     * Overridden if `SS_SESSION_SAVE_HANDLER_CLASS` is set.
      */
     private static ?string $save_handler = FileSessionHandler::class;
 
@@ -195,6 +198,18 @@ class Session
      * @var array
      */
     protected $changedData = [];
+
+    /**
+     * Get the session save handler if one has been configured.
+     */
+    public static function getSaveHandler(): ?SessionHandlerInterface
+    {
+        $serviceName = Environment::getEnv('SS_SESSION_SAVE_HANDLER_CLASS') ?: static::config()->get('save_handler');
+        if ($serviceName) {
+            return Injector::inst()->get($serviceName);
+        }
+        return null;
+    }
 
     /**
      * Get user agent for this request
@@ -310,9 +325,8 @@ class Session
                 }
 
                 // Set the session save handler if configured
-                $saveHandlerServiceName = static::config()->get('save_handler');
-                if ($saveHandlerServiceName !== null) {
-                    $saveHandler = Injector::inst()->get($saveHandlerServiceName);
+                $saveHandler = static::getSaveHandler();
+                if ($saveHandler) {
                     session_set_save_handler($saveHandler, true);
                 }
 

--- a/src/Control/SessionHandler/AbstractSessionHandler.php
+++ b/src/Control/SessionHandler/AbstractSessionHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Control\SessionHandler;
+
+use SessionHandlerInterface;
+use SessionUpdateTimestampHandlerInterface;
+use SilverStripe\Control\Session;
+
+abstract class AbstractSessionHandler implements SessionHandlerInterface, SessionUpdateTimestampHandlerInterface
+{
+    /**
+     * Get the session lifetime in seconds.
+     * Returns the cookie lifetime if it's non-zero, otherwise returns the garbage collection lifetime.
+     */
+    protected function getLifetime(): int
+    {
+        $cookieLifetime = (int) Session::config()->get('timeout');
+        if ($cookieLifetime) {
+            return $cookieLifetime;
+        }
+        return (int) ini_get('session.gc_maxlifetime');
+    }
+}

--- a/src/Control/SessionHandler/CacheSessionHandler.php
+++ b/src/Control/SessionHandler/CacheSessionHandler.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SilverStripe\Control\SessionHandler;
+
+use SensitiveParameter;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Session save handler that stores session data in an in a PSR-16 cache adapter.
+ */
+class CacheSessionHandler extends AbstractSessionHandler
+{
+    private CacheInterface $cacheAdapter;
+
+    public function __construct(CacheInterface $cacheAdapter)
+    {
+        $this->cacheAdapter = $cacheAdapter;
+    }
+
+    public function open(string $path, string $name): bool
+    {
+        // No action is required to open the session.
+        return true;
+    }
+
+    public function close(): bool
+    {
+        // No action is required to close the session.
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     * Clears the cache entry that represents this session ID.
+     */
+    public function destroy(#[SensitiveParameter] string $id): bool
+    {
+        return $this->cacheAdapter->delete($id);
+    }
+
+    /**
+     * @inheritDoc
+     * Clears all session cache which have a last modified datetime older than the session max lifetime.
+     */
+    public function gc(int $max_lifetime): int|false
+    {
+        // No action required - the cache adapter handles GC itself.
+        return 0;
+    }
+
+    /**
+     * @inheritDoc
+     * Returns data of a pre-existing session, or an empty string for a new session.
+     */
+    public function read(#[SensitiveParameter] string $id): string|false
+    {
+        return $this->cacheAdapter->get($id, '');
+    }
+
+    /**
+     * @inheritDoc
+     * Writes session data to a cache entry.
+     */
+    public function write(#[SensitiveParameter] string $id, string $data): bool
+    {
+        return $this->cacheAdapter->set($id, $data, $this->getLifetime());
+    }
+
+    /**
+     * @inheritDoc
+     * A session ID is valid if an entry for that session ID already exists and has not expired.
+     */
+    public function validateId(#[SensitiveParameter] string $id): bool
+    {
+        return $this->cacheAdapter->has($id);
+    }
+
+    /**
+     * @inheritDoc
+     * Called instead of write if session.lazy_write is enabled and no data has changed for this session.
+     */
+    public function updateTimestamp(#[SensitiveParameter] string $id, string $data): bool
+    {
+        // The cache interface doesn't let us just update TTL, so we have to set the data at the same time.
+        return $this->write($id, $data);
+    }
+}

--- a/src/Control/SessionHandler/CacheSessionHandler.php
+++ b/src/Control/SessionHandler/CacheSessionHandler.php
@@ -6,15 +6,15 @@ use SensitiveParameter;
 use Psr\SimpleCache\CacheInterface;
 
 /**
- * Session save handler that stores session data in an in a PSR-16 cache adapter.
+ * Session save handler that stores session data in an in a PSR-16 cache.
  */
 class CacheSessionHandler extends AbstractSessionHandler
 {
-    private CacheInterface $cacheAdapter;
+    private CacheInterface $cache;
 
-    public function __construct(CacheInterface $cacheAdapter)
+    public function __construct(CacheInterface $cache)
     {
-        $this->cacheAdapter = $cacheAdapter;
+        $this->cache = $cache;
     }
 
     public function open(string $path, string $name): bool
@@ -35,7 +35,7 @@ class CacheSessionHandler extends AbstractSessionHandler
      */
     public function destroy(#[SensitiveParameter] string $id): bool
     {
-        return $this->cacheAdapter->delete($id);
+        return $this->cache->delete($id);
     }
 
     /**
@@ -44,7 +44,7 @@ class CacheSessionHandler extends AbstractSessionHandler
      */
     public function gc(int $max_lifetime): int|false
     {
-        // No action required - the cache adapter handles GC itself.
+        // No action required - the cache handles GC itself.
         return 0;
     }
 
@@ -54,7 +54,7 @@ class CacheSessionHandler extends AbstractSessionHandler
      */
     public function read(#[SensitiveParameter] string $id): string|false
     {
-        return $this->cacheAdapter->get($id, '');
+        return $this->cache->get($id, '');
     }
 
     /**
@@ -63,7 +63,7 @@ class CacheSessionHandler extends AbstractSessionHandler
      */
     public function write(#[SensitiveParameter] string $id, string $data): bool
     {
-        return $this->cacheAdapter->set($id, $data, $this->getLifetime());
+        return $this->cache->set($id, $data, $this->getLifetime());
     }
 
     /**
@@ -72,7 +72,7 @@ class CacheSessionHandler extends AbstractSessionHandler
      */
     public function validateId(#[SensitiveParameter] string $id): bool
     {
-        return $this->cacheAdapter->has($id);
+        return $this->cache->has($id);
     }
 
     /**

--- a/src/Control/SessionHandler/DatabaseSessionHandler.php
+++ b/src/Control/SessionHandler/DatabaseSessionHandler.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace SilverStripe\Control\SessionHandler;
+
+use Psr\Log\LoggerInterface;
+use SensitiveParameter;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\Connect\Query;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\Queries\SQLDelete;
+use SilverStripe\ORM\Queries\SQLInsert;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Queries\SQLUpdate;
+
+/**
+ * Session save handler that stores session data in the database.
+ */
+class DatabaseSessionHandler extends AbstractSessionHandler
+{
+    use Configurable;
+
+    private static string $table_name = '_sessions';
+
+    public function open(string $path, string $name): bool
+    {
+        // No action is required to open the session.
+        return true;
+    }
+
+    public function close(): bool
+    {
+        // No action is required to close the session.
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     * Clears the cache entry that represents this session ID.
+     */
+    public function destroy(#[SensitiveParameter] string $id): bool
+    {
+        if (!$this->isDatabaseReady()) {
+            $this->logError('Could not remove session - database is not ready');
+            return false;
+        }
+
+        SQLDelete::create(
+            Convert::symbol2sql(static::config()->get('table_name')),
+            [Convert::symbol2sql('ID') => $id]
+        )->execute();
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     * Clears all session cache which have a last modified datetime older than the session max lifetime.
+     * Note that we use our own calculated session lifetime rather than the passed in lifetime which doesn't
+     * take Silverstripe CMS configuration values into account.
+     */
+    public function gc(int $max_lifetime): int|false
+    {
+        if (!$this->isDatabaseReady()) {
+            $this->logError('Could not perform session garbage collecttion - database is not ready');
+            return false;
+        }
+
+        SQLDelete::create(
+            Convert::symbol2sql(static::config()->get('table_name')),
+            [Convert::symbol2sql('Expiry') . ' < ?' => DBDatetime::now()->getTimestamp()]
+        )->execute();
+        return DB::affected_rows();
+    }
+
+    /**
+     * @inheritDoc
+     * Returns data of a pre-existing session, or an empty string for a new session.
+     */
+    public function read(#[SensitiveParameter] string $id): string|false
+    {
+        if (!$this->isDatabaseReady()) {
+            $this->logError('Could not read session - database is not ready');
+            return false;
+        }
+
+        /** @var Query $rows */
+        $rows = DB::withPrimary(fn() => $this->getSqlSelect($id)->execute());
+        if ($rows->numRecords() === 0) {
+            return '';
+        }
+        return $rows->record()['Data'];
+    }
+
+    /**
+     * @inheritDoc
+     * Writes session data to a cache entry.
+     */
+    public function write(#[SensitiveParameter] string $id, string $data): bool
+    {
+        if (!$this->isDatabaseReady()) {
+            $this->logError('Could not write session - database is not ready');
+            return false;
+        }
+
+        $table = Convert::symbol2sql(static::config()->get('table_name'));
+        $where = [Convert::symbol2sql('ID') => $id];
+        if ($this->sessionExists($id, true)) {
+            $query = SQLUpdate::create($table, where: $where);
+        } else {
+            $query = SQLInsert::create($table, $where);
+        }
+        $query->addAssignments([
+            Convert::symbol2sql('Data') => $data,
+            Convert::symbol2sql('Expiry') => DBDatetime::now()->getTimestamp() + $this->getLifetime(),
+        ]);
+        $query->execute();
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     * A session ID is valid if an entry for that session ID already exists and has not expired.
+     */
+    public function validateId(#[SensitiveParameter] string $id): bool
+    {
+        if (!$this->isDatabaseReady()) {
+            $this->logError('Could not validate session ID - database is not ready');
+            return false;
+        }
+        return $this->sessionExists($id);
+    }
+
+    /**
+     * @inheritDoc
+     * Called instead of write if session.lazy_write is enabled and no data has changed for this session.
+     */
+    public function updateTimestamp(#[SensitiveParameter] string $id, string $data): bool
+    {
+        // The logic for updating the timestamp ends up being effectively identical to just
+        // writing the session - there's no optimisation to be made by using separate logic.
+        return $this->write($id, $data);
+    }
+
+    /**
+     * Add the database table. This is called by an extension when building the db.
+     * Note that we don't just use a DataObject because:
+     * 1. We don't want things like versioning, fluent, etc to ever be able to affect sessions
+     * 2. We don't want developers to be affecting db operations via hooks (interact with sessions with the Session class)
+     * 3. We don't want sessions to be used in any other ways that DataObjects are often
+     * 4. We only want to build the table if this is the configured save handler
+     */
+    public function requireTable()
+    {
+        $fields = [
+            // ID will automatically be the primary key because of its name
+            'ID' => 'Varchar(64)',
+            'Expiry' => 'Int',
+            'Data' => 'Text',
+        ];
+        $indexes = [
+            'Expiry' => [
+                'type' => 'index',
+                'columns' => ['Expiry'],
+            ],
+        ];
+        DB::get_schema()->schemaUpdate(function () use ($fields, $indexes) {
+            DB::require_table(
+                static::config()->get('table_name'),
+                $fields,
+                $indexes,
+                true,
+                DataObject::config()->get('create_table_options')
+            );
+        });
+    }
+
+    /**
+     * Get an SQLSelect for selecting the data for the given session ID.
+     * If $allowExpired is false, expired sessions are explicitly excluded.
+     */
+    private function getSqlSelect(#[SensitiveParameter] string $id, bool $allowExpired = false): SQLSelect
+    {
+        $select = SQLSelect::create(
+            Convert::symbol2sql('Data'),
+            Convert::symbol2sql(static::config()->get('table_name')),
+            [Convert::symbol2sql('ID') => $id],
+        );
+        if (!$allowExpired) {
+            $select->addWhere([Convert::symbol2sql('Expiry') . ' >= ?' => DBDatetime::now()->getTimestamp()]);
+        }
+        return $select;
+    }
+
+    /**
+     * Check if a session with this ID exists.
+     * If $allowExpired is false, returns false for expired sessions.
+     */
+    private function sessionExists(#[SensitiveParameter] string $id, bool $allowExpired = false): bool
+    {
+        // Note this is the same logic used in DataQuery::exists()
+        $row = DB::withPrimary(function () use ($id, $allowExpired) {
+            $select = $this->getSqlSelect($id, $allowExpired);
+            $subQuerySql = $select->sql($params);
+            $selectExists = SQLSelect::create('1')->addWhere(['EXISTS (' . $subQuerySql . ')' => $params])->execute();
+            return $selectExists->record();
+        });
+        if ($row) {
+            $result = reset($row);
+        } else {
+            $result = false;
+        }
+        return $result === true || $result === 1 || $result === '1';
+    }
+
+    private function isDatabaseReady()
+    {
+        if (!DB::connection_attempted() || !DB::is_active()) {
+            return false;
+        }
+        return DB::get_schema()->hasTable(static::config()->get('table_name'));
+    }
+
+    private function logError(string $message): void
+    {
+        Injector::inst()->get(LoggerInterface::class)->error($message);
+    }
+}

--- a/src/Control/SessionHandler/DatabaseSessionHandler.php
+++ b/src/Control/SessionHandler/DatabaseSessionHandler.php
@@ -152,7 +152,7 @@ class DatabaseSessionHandler extends AbstractSessionHandler
      * 3. We don't want sessions to be used in any other ways that DataObjects are often
      * 4. We only want to build the table if this is the configured save handler
      */
-    public function requireTable()
+    public function requireTable(): void
     {
         $fields = [
             // ID will automatically be the primary key because of its name
@@ -215,9 +215,9 @@ class DatabaseSessionHandler extends AbstractSessionHandler
         return $result === true || $result === 1 || $result === '1';
     }
 
-    private function isDatabaseReady()
+    private function isDatabaseReady(): bool
     {
-        if (!DB::connection_attempted() || !DB::is_active()) {
+        if (!DB::is_active()) {
             return false;
         }
         return DB::get_schema()->hasTable(static::config()->get('table_name'));

--- a/src/Control/SessionHandler/DbBuildSessionExtension.php
+++ b/src/Control/SessionHandler/DbBuildSessionExtension.php
@@ -16,9 +16,9 @@ class DbBuildSessionExtension extends Extension
     /**
      * This extension hook is on TestSessionEnvironment, which is used by behat but not by phpunit.
      * For whatever reason, behat doesn't build the db the normal way, so we can't rely on the below
-     * onAfterbuild being run in that scenario.
+     * onAfterBuild being run in that scenario.
      */
-    protected function onAfterStartTestSession()
+    protected function onAfterStartTestSession(): void
     {
         $sessionHandler = $this->getSessionHandler();
         if (!$sessionHandler) {
@@ -35,7 +35,7 @@ class DbBuildSessionExtension extends Extension
     }
 
     /**
-     * This extension hook is on DbBuild, after building the database.
+     * This extension hook is in DbBuild::doBuild(), after building the database.
      */
     protected function onAfterBuild(PolyOutput $output): void
     {
@@ -53,11 +53,10 @@ class DbBuildSessionExtension extends Extension
 
     private function getSessionHandler(): ?DatabaseSessionHandler
     {
-        $sessionHandlerServiceName = Session::config()->get('save_handler');
-        if ($sessionHandlerServiceName === null) {
+        $sessionHandler = Session::getSaveHandler();
+        if ($sessionHandler === null) {
             return null;
         }
-        $sessionHandler = Injector::inst()->get($sessionHandlerServiceName);
         if (!is_a($sessionHandler, DatabaseSessionHandler::class)) {
             return null;
         }

--- a/src/Control/SessionHandler/DbBuildSessionExtension.php
+++ b/src/Control/SessionHandler/DbBuildSessionExtension.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\Control\SessionHandler;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\PolyExecution\PolyOutput;
+
+/**
+ * Builds the table for DatabaseSessionHandler if that is the configured session save handler.
+ */
+class DbBuildSessionExtension extends Extension
+{
+    /**
+     * This extension hook is on TestSessionEnvironment, which is used by behat but not by phpunit.
+     * For whatever reason, behat doesn't build the db the normal way, so we can't rely on the below
+     * onAfterbuild being run in that scenario.
+     */
+    protected function onAfterStartTestSession()
+    {
+        $sessionHandler = $this->getSessionHandler();
+        if (!$sessionHandler) {
+            return;
+        }
+
+        $output = PolyOutput::create(
+            Director::is_cli() ? PolyOutput::FORMAT_ANSI : PolyOutput::FORMAT_HTML,
+            PolyOutput::VERBOSITY_QUIET
+        );
+        $output->startList();
+        $sessionHandler->requireTable();
+        $output->stopList();
+    }
+
+    /**
+     * This extension hook is on DbBuild, after building the database.
+     */
+    protected function onAfterBuild(PolyOutput $output): void
+    {
+        $sessionHandler = $this->getSessionHandler();
+        if (!$sessionHandler) {
+            return;
+        }
+
+        $output->writeln('<options=bold>Creating table for session data</>');
+        $output->startList();
+        $sessionHandler->requireTable();
+        $output->stopList();
+        $output->writeln(['<options=bold>session database build completed!</>', '']);
+    }
+
+    private function getSessionHandler(): ?DatabaseSessionHandler
+    {
+        $sessionHandlerServiceName = Session::config()->get('save_handler');
+        if ($sessionHandlerServiceName === null) {
+            return null;
+        }
+        $sessionHandler = Injector::inst()->get($sessionHandlerServiceName);
+        if (!is_a($sessionHandler, DatabaseSessionHandler::class)) {
+            return null;
+        }
+        return $sessionHandler;
+    }
+}

--- a/src/Control/SessionHandler/FileSessionHandler.php
+++ b/src/Control/SessionHandler/FileSessionHandler.php
@@ -7,9 +7,6 @@ use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use SensitiveParameter;
-use SessionHandlerInterface;
-use SessionUpdateTimestampHandlerInterface;
-use SilverStripe\Control\Session;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Path;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -23,7 +20,7 @@ use Symfony\Component\Finder\Finder;
  * Similar to PHP's default filesystem session handler, except it doesn't lock the session file meaning
  * sessions are non-blocking.
  */
-class FileSessionHandler implements SessionHandlerInterface, SessionUpdateTimestampHandlerInterface
+class FileSessionHandler extends AbstractSessionHandler
 {
     public const string SESSION_FILE_PREFIX = 'sess_';
 
@@ -327,18 +324,6 @@ class FileSessionHandler implements SessionHandlerInterface, SessionUpdateTimest
             throw new RuntimeException('Could not read modified time of session file');
         }
         return $mTime < (DBDatetime::now()->getTimestamp() - $maxLifeInSeconds);
-    }
-
-    /**
-     * Returns the cookie lifetime if it's non-zero, otherwise returns the garbage collection lifetime.
-     */
-    private function getLifetime(): int
-    {
-        $cookieLifetime = (int) Session::config()->get('lifetime');
-        if ($cookieLifetime) {
-            return $cookieLifetime;
-        }
-        return (int) ini_get('session.gc_maxlifetime');
     }
 
     private function logError(string $message): void

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -440,6 +440,9 @@ class Injector implements ContainerInterface
             // if so, we need to instantiate and replace immediately
             if (isset($this->serviceCache[$id])) {
                 $this->updateSpecConstructor($spec);
+                if (isset($spec['factory'])) {
+                    $spec['factory'] = $this->parseBacktickConfig($spec['factory']);
+                }
                 $this->instantiate($spec, $id);
             }
         }
@@ -521,33 +524,9 @@ class Injector implements ContainerInterface
             return $this->get($id);
         }
 
-        // Evaluate constants surrounded by back ticks
-        $hasBacticks = false;
-        $allMissing = true;
-        // $value must start and end with backticks, though there can be multiple
-        // things being subsituted within $value e.g. "`VAR_ONE`:`VAR_TWO`:`VAR_THREE`"
-        if (preg_match('/^`.+`$/', $value ?? '')) {
-            $hasBacticks = true;
-            preg_match_all('/`(?<name>[^`]+)`/', $value, $matches);
-            foreach ($matches['name'] as $name) {
-                $envValue = Environment::getEnv($name);
-                $val = '';
-                if ($envValue !== false) {
-                    $val = $envValue;
-                } elseif (defined($name)) {
-                    $val = constant($name);
-                }
-                $value = str_replace("`$name`", $val, $value);
-                if ($val) {
-                    $allMissing = false;
-                }
-            }
+        if (is_string($value)) {
+            $value = $this->parseBacktickConfig($value);
         }
-        // silverstripe sometimes explictly expects a null value rather than just an empty string
-        if ($hasBacticks && $allMissing && $value === '') {
-            return null;
-        }
-
         return $value;
     }
 
@@ -1022,6 +1001,10 @@ class Injector implements ContainerInterface
             // Resolve references in constructor args
             $this->updateSpecConstructor($spec);
         }
+        // Update any backticked factory spec to get environment variables
+        if (isset($spec['factory'])) {
+            $spec['factory'] = $this->parseBacktickConfig($spec['factory']);
+        }
 
         // Build instance
         return $this->instantiate($spec, $name, $type);
@@ -1150,5 +1133,38 @@ class Injector implements ContainerInterface
     public function createWithArgs($name, $constructorArgs)
     {
         return $this->get($name, false, $constructorArgs);
+    }
+
+    /**
+     * Evaluate constants or environment variables surrounded by backticks
+     */
+    private function parseBacktickConfig(string $value): ?string
+    {
+        $hasBacticks = false;
+        $allMissing = true;
+        // $value must start and end with backticks, though there can be multiple
+        // things being subsituted within $value e.g. "`VAR_ONE`:`VAR_TWO`:`VAR_THREE`"
+        if (preg_match('/^`.+`$/', $value ?? '')) {
+            $hasBacticks = true;
+            preg_match_all('/`(?<name>[^`]+)`/', $value, $matches);
+            foreach ($matches['name'] as $name) {
+                $envValue = Environment::getEnv($name);
+                $val = '';
+                if ($envValue !== false) {
+                    $val = $envValue;
+                } elseif (defined($name)) {
+                    $val = constant($name);
+                }
+                $value = str_replace("`$name`", $val, $value);
+                if ($val) {
+                    $allMissing = false;
+                }
+            }
+        }
+        // silverstripe sometimes explictly expects a null value rather than just an empty string
+        if ($hasBacticks && $allMissing && $value === '') {
+            return null;
+        }
+        return $value;
     }
 }

--- a/tests/php/Control/SessionHandler/CacheSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/CacheSessionHandlerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace SilverStripe\Control\Tests\SessionHandler;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionProperty;
+use SilverStripe\Control\SessionHandler\CacheSessionHandler;
+use SilverStripe\Dev\SapphireTest;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+class CacheSessionHandlerTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    public static function provideRead(): array
+    {
+        return [
+            [
+                'sessionID' => 'existing-session',
+                'expected' => 'some-data',
+            ],
+            [
+                'sessionID' => 'new-session',
+                'expected' => '',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideRead')]
+    public function testRead(string $sessionID, string $expected): void
+    {
+        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cacheAdapter);
+        $cacheAdapter->set('existing-session', 'some-data');
+        $this->assertSame($expected, $handler->read($sessionID));
+    }
+
+    public function testReadExpired(): void
+    {
+        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cacheAdapter);
+        $cacheAdapter->set('existing-session', 'some-data', -1);
+        $this->assertSame('', $handler->read('existing-session'));
+    }
+
+    public static function provideWrite(): array
+    {
+        return [
+            [
+                'sessionID' => 'existing-session',
+            ],
+            [
+                'sessionID' => 'new-session',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideWrite')]
+    public function testWrite(string $sessionID): void
+    {
+        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cacheAdapter);
+        $cacheAdapter->set('existing-session', 'some-data');
+        $handler->write($sessionID, 'updated-data');
+        $this->assertSame('updated-data', $cacheAdapter->get($sessionID));
+    }
+
+    public static function provideDestroy(): array
+    {
+        return [
+            [
+                'sessionID' => 'existing-session',
+            ],
+            [
+                'sessionID' => 'new-session',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideDestroy')]
+    public function testDestroy(string $sessionID): void
+    {
+        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cacheAdapter);
+        $cacheAdapter->set('existing-session', 'some-data');
+        $this->assertTrue($handler->destroy($sessionID));
+        $this->assertNull($cacheAdapter->get($sessionID));
+    }
+
+    public static function provideValidateId(): array
+    {
+        return [
+            'new session (no file) is invalid' => [
+                'sessionID' => 'new-session',
+                'isExpired' => false,
+                'expected' => false,
+            ],
+            'existing session is valid' => [
+                'sessionID' => 'existing-session',
+                'isExpired' => false,
+                'expected' => true,
+            ],
+            'expired existing session is invalid' => [
+                'sessionID' => 'existing-session',
+                'isExpired' => true,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidateId')]
+    public function testValidateId(string $sessionID, bool $isExpired, bool $expected): void
+    {
+        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cacheAdapter);
+        $cacheAdapter->set('existing-session', 'some-data', $isExpired ? -1 : 60);
+        $this->assertSame($expected, $handler->validateId($sessionID));
+    }
+
+    public function testUpdateTimestamp(): void
+    {
+        $arrayAdapter = new ArrayAdapter();
+        $cacheAdapter = new Psr16Cache($arrayAdapter);
+        $handler = new CacheSessionHandler($cacheAdapter);
+        $cacheAdapter->set('existing-session', 'some-data', 999999999);
+
+        $this->assertTrue($handler->updateTimestamp('existing-session', 'new content'));
+        $this->assertTrue($cacheAdapter->has('existing-session'));
+        $reflectionExpiries = new ReflectionProperty($arrayAdapter, 'expiries');
+        $reflectionExpiries->setAccessible(true);
+        $expiry = $reflectionExpiries->getValue($arrayAdapter)['existing-session'];
+
+        // 999999 is way more than the number of seconds the session should live for
+        // so calling updateTimestamp should set it to less than that but more than right now
+        // We can't do an exact time check because that would obviously introduce timing issues
+        // and Symfony's cache stuff doesn't use our internal DateTime so we can't set a mock now.
+        $this->assertLessThan(microtime(true) + 999999, $expiry);
+        $this->assertGreaterThan(microtime(true), $expiry);
+        $this->assertSame('new content', $cacheAdapter->get('existing-session'));
+    }
+}

--- a/tests/php/Control/SessionHandler/CacheSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/CacheSessionHandlerTest.php
@@ -30,17 +30,17 @@ class CacheSessionHandlerTest extends SapphireTest
     #[DataProvider('provideRead')]
     public function testRead(string $sessionID, string $expected): void
     {
-        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
-        $handler = new CacheSessionHandler($cacheAdapter);
-        $cacheAdapter->set('existing-session', 'some-data');
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cache);
+        $cache->set('existing-session', 'some-data');
         $this->assertSame($expected, $handler->read($sessionID));
     }
 
     public function testReadExpired(): void
     {
-        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
-        $handler = new CacheSessionHandler($cacheAdapter);
-        $cacheAdapter->set('existing-session', 'some-data', -1);
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cache);
+        $cache->set('existing-session', 'some-data', -1);
         $this->assertSame('', $handler->read('existing-session'));
     }
 
@@ -59,11 +59,11 @@ class CacheSessionHandlerTest extends SapphireTest
     #[DataProvider('provideWrite')]
     public function testWrite(string $sessionID): void
     {
-        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
-        $handler = new CacheSessionHandler($cacheAdapter);
-        $cacheAdapter->set('existing-session', 'some-data');
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cache);
+        $cache->set('existing-session', 'some-data');
         $handler->write($sessionID, 'updated-data');
-        $this->assertSame('updated-data', $cacheAdapter->get($sessionID));
+        $this->assertSame('updated-data', $cache->get($sessionID));
     }
 
     public static function provideDestroy(): array
@@ -81,11 +81,11 @@ class CacheSessionHandlerTest extends SapphireTest
     #[DataProvider('provideDestroy')]
     public function testDestroy(string $sessionID): void
     {
-        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
-        $handler = new CacheSessionHandler($cacheAdapter);
-        $cacheAdapter->set('existing-session', 'some-data');
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cache);
+        $cache->set('existing-session', 'some-data');
         $this->assertTrue($handler->destroy($sessionID));
-        $this->assertNull($cacheAdapter->get($sessionID));
+        $this->assertNull($cache->get($sessionID));
     }
 
     public static function provideValidateId(): array
@@ -112,21 +112,21 @@ class CacheSessionHandlerTest extends SapphireTest
     #[DataProvider('provideValidateId')]
     public function testValidateId(string $sessionID, bool $isExpired, bool $expected): void
     {
-        $cacheAdapter = new Psr16Cache(new ArrayAdapter());
-        $handler = new CacheSessionHandler($cacheAdapter);
-        $cacheAdapter->set('existing-session', 'some-data', $isExpired ? -1 : 60);
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $handler = new CacheSessionHandler($cache);
+        $cache->set('existing-session', 'some-data', $isExpired ? -1 : 60);
         $this->assertSame($expected, $handler->validateId($sessionID));
     }
 
     public function testUpdateTimestamp(): void
     {
         $arrayAdapter = new ArrayAdapter();
-        $cacheAdapter = new Psr16Cache($arrayAdapter);
-        $handler = new CacheSessionHandler($cacheAdapter);
-        $cacheAdapter->set('existing-session', 'some-data', 999999999);
+        $cache = new Psr16Cache($arrayAdapter);
+        $handler = new CacheSessionHandler($cache);
+        $cache->set('existing-session', 'some-data', 999999999);
 
         $this->assertTrue($handler->updateTimestamp('existing-session', 'new content'));
-        $this->assertTrue($cacheAdapter->has('existing-session'));
+        $this->assertTrue($cache->has('existing-session'));
         $reflectionExpiries = new ReflectionProperty($arrayAdapter, 'expiries');
         $reflectionExpiries->setAccessible(true);
         $expiry = $reflectionExpiries->getValue($arrayAdapter)['existing-session'];
@@ -137,6 +137,6 @@ class CacheSessionHandlerTest extends SapphireTest
         // and Symfony's cache stuff doesn't use our internal DateTime so we can't set a mock now.
         $this->assertLessThan(microtime(true) + 999999, $expiry);
         $this->assertGreaterThan(microtime(true), $expiry);
-        $this->assertSame('new content', $cacheAdapter->get('existing-session'));
+        $this->assertSame('new content', $cache->get('existing-session'));
     }
 }

--- a/tests/php/Control/SessionHandler/DatabaseSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/DatabaseSessionHandlerTest.php
@@ -16,23 +16,34 @@ class DatabaseSessionHandlerTest extends SapphireTest
 
     protected static $fixture_file = 'DatabaseSessionHandlerTest.yml';
 
+    private string|false $gcLifeTime;
+
     public function onBeforeLoadFixtures(): void
     {
         // Add the sessions table
         $handler = new DatabaseSessionHandler();
-        DB::get_schema()->schemaUpdate(fn () => $handler->requireTable());
+        DB::get_schema()->schemaUpdate(fn() => $handler->requireTable());
     }
 
     protected function setUp(): void
     {
         parent::setUp();
+        $this->gcLifeTime = ini_get('session.gc_maxlifetime');
         $expiry = DBDatetime::now()->getTimestamp() + 1000;
-        DB::query('UPDATE "_sessions" SET "Expiry" = ' . $expiry . ' WHERE "ID" = \'valid\'');
+        $tableName = DatabaseSessionHandler::config()->get('table_name');
+        DB::query('UPDATE "' . $tableName . '" SET "Expiry" = ' . $expiry . ' WHERE "ID" = \'valid\'');
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('session.gc_maxlifetime', $this->gcLifeTime);
+        parent::tearDown();
     }
 
     public function testIdIsPrimaryKey(): void
     {
-        $result = DB::query('SHOW KEYS FROM "_sessions" WHERE "Key_name" = \'PRIMARY\'');
+        $tableName = DatabaseSessionHandler::config()->get('table_name');
+        $result = DB::query('SHOW KEYS FROM ' . $tableName . ' WHERE "Key_name" = \'PRIMARY\'');
         $this->assertSame('ID', $result->record()['Column_name']);
     }
 
@@ -63,7 +74,8 @@ class DatabaseSessionHandlerTest extends SapphireTest
 
         if ($sessionID === 'new-session') {
             // Make sure no new file is created for new sessions
-            $result = DB::query('SELECT "ID" FROM "_sessions" WHERE "ID" = \'new-session\'');
+            $tableName = DatabaseSessionHandler::config()->get('table_name');
+            $result = DB::query('SELECT "ID" FROM ' . $tableName . ' WHERE "ID" = \'new-session\'');
             $this->assertSame(0, $result->numRecords());
         }
     }
@@ -109,7 +121,8 @@ class DatabaseSessionHandlerTest extends SapphireTest
         $expiry = $now->getTimestamp() + $expectedLifetime;
 
         $this->assertTrue($handler->write($sessionID, 'New content now'));
-        $result = DB::query('SELECT * FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+        $tableName = DatabaseSessionHandler::config()->get('table_name');
+        $result = DB::query('SELECT * FROM ' . $tableName . ' WHERE "ID" = \'' . $sessionID . '\'');
         $this->assertSame(1, $result->numRecords());
         $session = $result->record();
         $this->assertSame('New content now', $session['Data']);
@@ -137,7 +150,8 @@ class DatabaseSessionHandlerTest extends SapphireTest
         $handler = new DatabaseSessionHandler();
 
         $this->assertTrue($handler->destroy($sessionID));
-        $result = DB::query('SELECT "ID" FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+        $tableName = DatabaseSessionHandler::config()->get('table_name');
+        $result = DB::query('SELECT "ID" FROM ' . $tableName . ' WHERE "ID" = \'' . $sessionID . '\'');
         $this->assertSame(0, $result->numRecords());
     }
 
@@ -181,6 +195,7 @@ class DatabaseSessionHandlerTest extends SapphireTest
     #[DataProvider('provideGc')]
     public function testGc(int $gcLifetime, int $configLifetime, array $sessionLifetimeMap, array $expectDeleted): void
     {
+        $tableName = DatabaseSessionHandler::config()->get('table_name');
         ini_set('session.gc_maxlifetime', $gcLifetime);
         Session::config()->set('timeout', $configLifetime);
         $lifetime = ($configLifetime > 0) ? $configLifetime : $gcLifetime;
@@ -195,7 +210,7 @@ class DatabaseSessionHandlerTest extends SapphireTest
         foreach ($sessionLifetimeMap as $sessionID => $lifeToDate) {
             $expiry = $now->getTimestamp() + ($lifetime - $lifeToDate);
             DB::query(sprintf(
-                'INSERT INTO "_sessions" ("ID", "Data", "Expiry") VALUES (\'%s\', \'%s\', \'%s\')',
+                'INSERT INTO ' . $tableName . ' ("ID", "Data", "Expiry") VALUES (\'%s\', \'%s\', \'%s\')',
                 $sessionID,
                 'original content',
                 $expiry
@@ -205,7 +220,7 @@ class DatabaseSessionHandlerTest extends SapphireTest
         $numDeleted = $handler->gc(1);
         // Check it deleted the right things
         foreach ($expectDeleted as $sessionID) {
-            $result = DB::query('SELECT "ID" FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+            $result = DB::query('SELECT "ID" FROM ' . $tableName . ' WHERE "ID" = \'' . $sessionID . '\'');
             $this->assertSame(0, $result->numRecords());
         }
         $this->assertSame(count($expectDeleted), $numDeleted);
@@ -257,6 +272,7 @@ class DatabaseSessionHandlerTest extends SapphireTest
     #[DataProvider('provideUpdateTimestamp')]
     public function testUpdateTimestamp(string $sessionID, string $expectedContent): void
     {
+        $tableName = DatabaseSessionHandler::config()->get('table_name');
         $handler = new DatabaseSessionHandler();
         $now = DBDatetime::now();
         $reflectionGetLifetime = new ReflectionMethod($handler, 'getLifetime');
@@ -266,7 +282,7 @@ class DatabaseSessionHandlerTest extends SapphireTest
             $this->assertTrue($handler->updateTimestamp($sessionID, 'new content'));
         });
 
-        $result = DB::query('SELECT * FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+        $result = DB::query('SELECT * FROM ' . $tableName . ' WHERE "ID" = \'' . $sessionID . '\'');
         $this->assertSame(1, $result->numRecords());
         $session = $result->record();
         $this->assertSame($now->getTimestamp() + $lifetime, $session['Expiry']);

--- a/tests/php/Control/SessionHandler/DatabaseSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/DatabaseSessionHandlerTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace SilverStripe\Control\Tests\SessionHandler;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use SilverStripe\Control\Session;
+use SilverStripe\Control\SessionHandler\DatabaseSessionHandler;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBDatetime;
+
+class DatabaseSessionHandlerTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    protected static $fixture_file = 'DatabaseSessionHandlerTest.yml';
+
+    public function onBeforeLoadFixtures(): void
+    {
+        // Add the sessions table
+        $handler = new DatabaseSessionHandler();
+        DB::get_schema()->schemaUpdate(fn () => $handler->requireTable());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $expiry = DBDatetime::now()->getTimestamp() + 1000;
+        DB::query('UPDATE "_sessions" SET "Expiry" = ' . $expiry . ' WHERE "ID" = \'valid\'');
+    }
+
+    public function testIdIsPrimaryKey(): void
+    {
+        $result = DB::query('SHOW KEYS FROM "_sessions" WHERE "Key_name" = \'PRIMARY\'');
+        $this->assertSame('ID', $result->record()['Column_name']);
+    }
+
+    public static function provideRead(): array
+    {
+        return [
+            'new session (aka no file)' => [
+                'sessionID' => 'new-session',
+                'expected' => '',
+            ],
+            'existing session' => [
+                'sessionID' => 'valid',
+                'expected' => 'this one is valid',
+            ],
+            'expired session' => [
+                'sessionID' => 'expired',
+                'expected' => '',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideRead')]
+    public function testRead(string $sessionID, string $expected): void
+    {
+        $handler = new DatabaseSessionHandler();
+
+        $this->assertSame($expected, $handler->read($sessionID));
+
+        if ($sessionID === 'new-session') {
+            // Make sure no new file is created for new sessions
+            $result = DB::query('SELECT "ID" FROM "_sessions" WHERE "ID" = \'new-session\'');
+            $this->assertSame(0, $result->numRecords());
+        }
+    }
+
+    public static function provideWrite(): array
+    {
+        return [
+            'overrides existing session' => [
+                'sessionID' => 'valid',
+                'gcLifetime' => 100,
+                'configLifetime' => 500,
+                'expectedLifetime' => 500,
+            ],
+            'overrides expired session' => [
+                'sessionID' => 'expired',
+                'gcLifetime' => 500,
+                'configLifetime' => 100,
+                'expectedLifetime' => 100,
+            ],
+            'creates new session' => [
+                'sessionID' => 'new-session',
+                'gcLifetime' => 0,
+                'configLifetime' => 150,
+                'expectedLifetime' => 150,
+            ],
+            'uses gc for lifetime fallback' => [
+                'sessionID' => 'new-session',
+                'gcLifetime' => 200,
+                'configLifetime' => 0,
+                'expectedLifetime' => 200,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideWrite')]
+    public function testWrite(string $sessionID, int $gcLifetime, int $configLifetime, int $expectedLifetime): void
+    {
+        ini_set('session.gc_maxlifetime', $gcLifetime);
+        Session::config()->set('timeout', $configLifetime);
+        $handler = new DatabaseSessionHandler();
+        $now = DBDatetime::now();
+        DBDatetime::set_mock_now($now);
+        $expiry = $now->getTimestamp() + $expectedLifetime;
+
+        $this->assertTrue($handler->write($sessionID, 'New content now'));
+        $result = DB::query('SELECT * FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+        $this->assertSame(1, $result->numRecords());
+        $session = $result->record();
+        $this->assertSame('New content now', $session['Data']);
+        $this->assertSame($expiry, $session['Expiry']);
+    }
+
+    public static function provideDestroy(): array
+    {
+        return [
+            'deletes existing session' => [
+                'sessionID' => 'valid',
+            ],
+            'deletes expired session' => [
+                'sessionID' => 'expired',
+            ],
+            'no action for missing session' => [
+                'sessionID' => 'new-session'
+            ],
+        ];
+    }
+
+    #[DataProvider('provideDestroy')]
+    public function testDestroy(string $sessionID): void
+    {
+        $handler = new DatabaseSessionHandler();
+
+        $this->assertTrue($handler->destroy($sessionID));
+        $result = DB::query('SELECT "ID" FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+        $this->assertSame(0, $result->numRecords());
+    }
+
+    public static function provideGc(): array
+    {
+        return [
+            'respect config' => [
+                'gcLifetime' => 100,
+                'configLifetime' => 500,
+                'sessionLifetimeMap' => [
+                    'session1' => 50,
+                    'session2' => 550,
+                    'session3' => 150,
+                    'session4' => 1000,
+                ],
+                'expectDeleted' => [
+                    'session2',
+                    'session4',
+                    'expired',
+                ],
+            ],
+            'fall back on gc' => [
+                'gcLifetime' => 100,
+                'configLifetime' => 0,
+                'sessionLifetimeMap' => [
+                    'session1' => 50,
+                    'session2' => 550,
+                    'session3' => 150,
+                    'session4' => 1000,
+                ],
+                'expectDeleted' => [
+                    'session2',
+                    'session3',
+                    'session4',
+                    'expired',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGc')]
+    public function testGc(int $gcLifetime, int $configLifetime, array $sessionLifetimeMap, array $expectDeleted): void
+    {
+        ini_set('session.gc_maxlifetime', $gcLifetime);
+        Session::config()->set('timeout', $configLifetime);
+        $lifetime = ($configLifetime > 0) ? $configLifetime : $gcLifetime;
+        $handler = new DatabaseSessionHandler();
+
+        // Create the dummy files and set their modified time as appropriate
+        // Use symfony filesystem so that any subdirs are automatically created
+        $now = DBDatetime::now();
+        DBDatetime::set_mock_now($now);
+        // $lifeToDate represents how long ago the session was last written to
+        // so we need to calculate its expiry date based on how much lifetime is left.
+        foreach ($sessionLifetimeMap as $sessionID => $lifeToDate) {
+            $expiry = $now->getTimestamp() + ($lifetime - $lifeToDate);
+            DB::query(sprintf(
+                'INSERT INTO "_sessions" ("ID", "Data", "Expiry") VALUES (\'%s\', \'%s\', \'%s\')',
+                $sessionID,
+                'original content',
+                $expiry
+            ));
+        }
+        // Run gc
+        $numDeleted = $handler->gc(1);
+        // Check it deleted the right things
+        foreach ($expectDeleted as $sessionID) {
+            $result = DB::query('SELECT "ID" FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+            $this->assertSame(0, $result->numRecords());
+        }
+        $this->assertSame(count($expectDeleted), $numDeleted);
+    }
+
+    public static function provideValidateId(): array
+    {
+        return [
+            'new session is invalid' => [
+                'sessionID' => 'new-session',
+                'expected' => false,
+            ],
+            'existing session is valid' => [
+                'sessionID' => 'valid',
+                'expected' => true,
+            ],
+            'expired existing session is invalid' => [
+                'sessionID' => 'expired',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidateId')]
+    public function testValidateId(string $sessionID, bool $expected): void
+    {
+        $handler = new DatabaseSessionHandler();
+        $this->assertSame($expected, $handler->validateId($sessionID));
+    }
+
+    public static function provideUpdateTimestamp(): array
+    {
+        return [
+            'session already exists' => [
+                'sessionID' => 'valid',
+                'expectedContent' => 'new content',
+            ],
+            'session already expired' => [
+                'sessionID' => 'expired',
+                'expectedContent' => 'new content',
+            ],
+            'session doesnt exist (edge case)' => [
+                'sessionID' => 'new-session',
+                'expectedContent' => 'new content',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideUpdateTimestamp')]
+    public function testUpdateTimestamp(string $sessionID, string $expectedContent): void
+    {
+        $handler = new DatabaseSessionHandler();
+        $now = DBDatetime::now();
+        $reflectionGetLifetime = new ReflectionMethod($handler, 'getLifetime');
+        $lifetime = $reflectionGetLifetime->invoke($handler);
+
+        DBDatetime::withFixedNow($now, function () use ($handler, $sessionID) {
+            $this->assertTrue($handler->updateTimestamp($sessionID, 'new content'));
+        });
+
+        $result = DB::query('SELECT * FROM "_sessions" WHERE "ID" = \'' . $sessionID . '\'');
+        $this->assertSame(1, $result->numRecords());
+        $session = $result->record();
+        $this->assertSame($now->getTimestamp() + $lifetime, $session['Expiry']);
+        $this->assertSame($expectedContent, $session['Data']);
+    }
+}

--- a/tests/php/Control/SessionHandler/DatabaseSessionHandlerTest.yml
+++ b/tests/php/Control/SessionHandler/DatabaseSessionHandlerTest.yml
@@ -1,0 +1,10 @@
+_sessions:
+  validSession:
+    ID: 'valid'
+    # the expiry will be set in setUp()
+    Expiry: 12345
+    Data: 'this one is valid'
+  expiredSession:
+    ID: 'expired'
+    Expiry: 12345
+    Data: 'this one is expired'

--- a/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
@@ -19,6 +19,20 @@ class FileSessionHandlerTest extends SapphireTest
 
     protected $usesDatabase = false;
 
+    private string|false $gcLifeTime;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->gcLifeTime = ini_get('session.gc_maxlifetime');
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('session.gc_maxlifetime', $this->gcLifeTime);
+        parent::tearDown();
+    }
+
     public static function provideOpen(): array
     {
         return [

--- a/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
@@ -481,7 +481,7 @@ class FileSessionHandlerTest extends SapphireTest
         $handler->open($baseDir, 'PHPSESSID');
 
         ini_set('session.gc_maxlifetime', $gcLifetime);
-        Session::config()->set('lifetime', $configLifetime);
+        Session::config()->set('timeout', $configLifetime);
 
         try {
             $this->withSessionExpiry($nonSessionFilePath, function () use ($sessionFilesLifetimeMap, $handler, $nonSessionFilePath, $expectDeleted) {

--- a/tests/php/Control/SessionTest.php
+++ b/tests/php/Control/SessionTest.php
@@ -16,7 +16,11 @@ use SilverStripe\Control\NullHTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use SilverStripe\Control\SessionHandler\DatabaseSessionHandler;
+use SilverStripe\Control\SessionHandler\FileSessionHandler;
+use SilverStripe\Core\Environment;
 
 /**
  * Tests to cover the {@link Session} class
@@ -494,5 +498,47 @@ class SessionTest extends SapphireTest
         $this->expectException(LogicException::class);
         Config::modify()->set(Session::class, 'cookie_samesite', 'invalid');
         $methodBuildCookieParams->invoke($session, new NullHTTPRequest());
+    }
+
+    public static function provideGetSaveHandler(): array
+    {
+        return [
+            'unset handler' => [
+                'config' => null,
+                'envVar' => null,
+                'expectedClass' => null,
+            ],
+            'set env var' => [
+                'config' => null,
+                'envVar' => DatabaseSessionHandler::class,
+                'expectedClass' => DatabaseSessionHandler::class,
+            ],
+            'set config' => [
+                'config' => DatabaseSessionHandler::class,
+                'envVar' => null,
+                'expectedClass' => DatabaseSessionHandler::class,
+            ],
+            'env var overrides config' => [
+                'config' => DatabaseSessionHandler::class,
+                'envVar' => FileSessionHandler::class,
+                'expectedClass' => FileSessionHandler::class,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetSaveHandler')]
+    public function testGetSaveHandler(?string $config, ?string $envVar, ?string $expectedClass): void
+    {
+        Session::config()->set('save_handler', $config);
+        if ($envVar !== null) {
+            Environment::setEnv('SS_SESSION_SAVE_HANDLER_CLASS', $envVar);
+        }
+
+        $handler = Session::getSaveHandler();
+        if ($expectedClass === null) {
+            $this->assertNull($handler);
+        } else {
+            $this->assertInstanceOf($expectedClass, $handler);
+        }
     }
 }

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -28,6 +28,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use stdClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Tests\Injector\InjectorTest\SimpleFactory;
 
 define('TEST_SERVICES', __DIR__ . '/AopProxyServiceTest');
 
@@ -877,6 +878,18 @@ class InjectorTest extends SapphireTest
         // Unregister service by class
         $injector->unregisterNamedObject(TestObject::class);
         $this->assertFalse($injector->has(TestObject::class));
+    }
+
+    public function testFactoryWithBackticks(): void
+    {
+        Environment::setEnv('SS_TEST_MY_BACKTICK_FACTORY', SimpleFactory::class);
+        $injector = new Injector();
+        $injector->load([
+            'SomeClass.backtick-factory' => [
+                'factory' => '`SS_TEST_MY_BACKTICK_FACTORY`'
+            ],
+        ]);
+        $this->assertInstanceOf(TestObject::class, $injector->get('SomeClass.backtick-factory'));
     }
 
     public function testCreateConfiggedObjectWithCustomConstructorArgs()

--- a/tests/php/Core/Injector/InjectorTest/SimpleFactory.php
+++ b/tests/php/Core/Injector/InjectorTest/SimpleFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Injector\InjectorTest;
+
+use SilverStripe\Core\Injector\Factory;
+
+class SimpleFactory implements Factory
+{
+    public function create(string $service, array $params = []): ?object
+    {
+        return new TestObject();
+    }
+}


### PR DESCRIPTION
Doing this in several commits - DO NOT SQUASH

Commit 1: The cache-based session handler that can be used for Redis and Memcached
Commit 2: The database session handler
Commit 3: Add new environment variable to set the save handler
Commit 4: Injector allows backticks in the `factory` key now. This isn't a breaking change, because using backticks for that before would be trying to get a class name that has backticks in it, which PHP doesn't allow.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11719