### PR TITLE
NEW Add method to check if a class is ready for db queries

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -99,6 +99,15 @@ class DataObjectSchema
     protected $tableNames = [];
 
     /**
+     * Array of classes that have been confirmed ready for database queries.
+     * Once the database has been verified as ready, it will not do the
+     * checks again.
+     *
+     * @var array<string, boolean>
+     */
+    protected array $tableReadyClasses = [];
+
+    /**
      * Clear cached table names
      */
     public function reset()
@@ -108,6 +117,7 @@ class DataObjectSchema
         $this->databaseIndexes = [];
         $this->defaultDatabaseIndexes = [];
         $this->compositeFields = [];
+        $this->tableReadyClasses = [];
     }
 
     /**
@@ -760,6 +770,89 @@ class DataObjectSchema
             throw new InvalidArgumentException("Invalid sort() column");
         }
         return [$match['table'], $match['column'], $match['direction'] ?? 'ASC'];
+    }
+
+    /**
+     * Check if all tables and field columns for a class exist in the database.
+     */
+    public function tablesAreReadyForClass(string $class): bool
+    {
+        if (!is_subclass_of($class, DataObject::class)) {
+            throw new InvalidArgumentException("$class is not a subclass of " . DataObject::class);
+        }
+
+        // Bail if there's no active database connection yet
+        if (!DB::connection_attempted() || !DB::is_active()) {
+            return false;
+        }
+
+        // Don't check again if we already know the db is ready for this class.
+        // Necessary here before the loop to catch situations where a subclass
+        // is forced as ready without having to check all the superclasses.
+        if (!empty($this->tableReadyClasses[$class])) {
+            return true;
+        }
+
+        // Check if all tables and fields required for the class exist in the database.
+        $requiredClasses = ClassInfo::dataClassesFor($class);
+        foreach ($requiredClasses as $required) {
+            // Skip test classes, as not all test classes are scaffolded at once
+            if (is_a($required, TestOnly::class, true)) {
+                continue;
+            }
+
+            // Don't check again if we already know the db is ready for this class.
+            if (!empty($this->tableReadyClasses[$class])) {
+                continue;
+            }
+
+            // if any of the tables aren't created in the database
+            $table = $this->tableName($required);
+            if (!ClassInfo::hasTable($table)) {
+                return false;
+            }
+
+            // Extensions aren't applied until a class is instantiated for
+            // the first time, so create a singleton to ensure extensions are applied.
+            singleton($required);
+
+            // if any of the tables haven't had columns added yet
+            $dbFields = DB::field_list($table);
+            if (empty($dbFields)) {
+                return false;
+            }
+
+            // if any columns are missing from the db
+            $objFields = $this->databaseFields($required, false);
+            $missingFields = array_diff_key($objFields, $dbFields);
+            if ($missingFields) {
+                return false;
+            }
+
+            // Add each ready class to the cached array.
+            $this->tableReadyClasses[$required] = true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resets the cache for tablesAreReadyForClass.
+     *
+     * @param string|null $class The specific class to be cleared.
+     * If not passed, the cache for all classes is cleared.
+     * If passed, the class and all classes in its hierarchy will be cleared.
+     */
+    public function clearTableReadyForClass(?string $class = null): void
+    {
+        if ($class) {
+            $clearClasses = ClassInfo::dataClassesFor($class);
+            foreach ($clearClasses as $clear) {
+                unset($this->tableReadyClasses[$clear]);
+            }
+        } else {
+            $this->tableReadyClasses = [];
+        }
     }
 
     /**

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -181,6 +181,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * checks again.
      *
      * @var bool
+     * @deprecated 6.1 Use `DataObject::getSchema()->tableReadyClasses()` instead
      */
     protected static $database_is_ready = false;
 
@@ -1103,41 +1104,19 @@ class Security extends Controller implements TemplateGlobalProvider
             return Security::$database_is_ready;
         }
 
-        $requiredClasses = ClassInfo::dataClassesFor(Member::class);
-        $requiredClasses[] = Group::class;
-        $requiredClasses[] = Permission::class;
+        $toCheck = [
+            Member::class,
+            Group::class,
+            Permission::class,
+        ];
         $schema = DataObject::getSchema();
-        foreach ($requiredClasses as $class) {
-            // Skip test classes, as not all test classes are scaffolded at once
-            if (is_a($class, TestOnly::class, true)) {
-                continue;
-            }
-
-            // if any of the tables aren't created in the database
-            $table = $schema->tableName($class);
-            if (!ClassInfo::hasTable($table)) {
-                return false;
-            }
-
-            // HACK: Extensions aren't applied until a class is instantiated for
-            // the first time, so create an instance here.
-            singleton($class);
-
-            // if any of the tables don't have all fields mapped as table columns
-            $dbFields = DB::field_list($table);
-            if (!$dbFields) {
-                return false;
-            }
-
-            $objFields = $schema->databaseFields($class, false);
-            $missingFields = array_diff_key($objFields ?? [], $dbFields);
-
-            if ($missingFields) {
+        foreach ($toCheck as $class) {
+            if (!$schema->tablesAreReadyForClass($class)) {
                 return false;
             }
         }
-        Security::$database_is_ready = true;
 
+        Security::$database_is_ready = true;
         return true;
     }
 
@@ -1148,6 +1127,15 @@ class Security extends Controller implements TemplateGlobalProvider
     {
         Security::$database_is_ready = null;
         Security::$force_database_is_ready = null;
+        $toClear = [
+            Member::class,
+            Group::class,
+            Permission::class,
+        ];
+        $schema = DataObject::getSchema();
+        foreach ($toClear as $class) {
+            $schema->clearTableReadyForClass($class);
+        }
     }
 
     /**

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -9,6 +9,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\FieldType\DBMoney;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
+use SilverStripe\ORM\Tests\DataObjectSchemaTest\AdditionalFieldsExtension;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\AllIndexes;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\BaseClass;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\BaseDataClass;
@@ -22,6 +23,10 @@ use SilverStripe\ORM\Tests\DataObjectSchemaTest\NoFields;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\WithCustomTable;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\WithRelation;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Folder;
+use SilverStripe\Assets\Image;
+use SilverStripe\ORM\DB;
 
 /**
  * Tests schema inspection of DataObjects
@@ -41,6 +46,10 @@ class DataObjectSchemaTest extends SapphireTest
         WithRelation::class,
         DefaultTableName::class,
         AllIndexes::class,
+    ];
+
+    protected static $required_extensions = [
+        Folder::class => [AdditionalFieldsExtension::class],
     ];
 
     /**
@@ -121,7 +130,7 @@ class DataObjectSchemaTest extends SapphireTest
 
         $this->assertEquals(
             'DataObjectSchemaTest_HasFields',
-            $schema->tableForField(HasFields::Class, 'Description')
+            $schema->tableForField(HasFields::class, 'Description')
         );
 
         // Class and table differ for this model
@@ -495,5 +504,54 @@ class DataObjectSchemaTest extends SapphireTest
                 'expected' => true,
             ],
         ];
+    }
+
+    public function testTablesAreReadyForClass(): void
+    {
+        $schema = DataObject::getSchema();
+        // The database schema should be fully created by the time the test runs
+        $this->assertTrue($schema->tablesAreReadyForClass(File::class), 'File table should be ready at start');
+        // Note that Image doesn't have its own table but should still return true
+        $this->assertTrue($schema->tablesAreReadyForClass(Image::class), 'Image table should be ready at start');
+        $this->assertTrue($schema->tablesAreReadyForClass(Folder::class), 'Folder table should be ready at start');
+
+        // Reset cache and drop a column from the subclass. See AdditionalFieldsExtension
+        $schema->clearTableReadyForClass();
+        DB::query(sprintf(
+            'ALTER TABLE "%s" DROP COLUMN "SomeField";',
+            DataObject::getSchema()->tableForField(Folder::class, 'SomeField')
+        ));
+        $this->assertTrue($schema->tablesAreReadyForClass(File::class), 'File table should be ready after drop column');
+        $this->assertTrue($schema->tablesAreReadyForClass(Image::class), 'Image table should be ready after drop column');
+        $this->assertFalse($schema->tablesAreReadyForClass(Folder::class), 'Folder table should NOT be ready after drop column');
+
+        // build the expected database schema and reset cache
+        static::resetDBSchema();
+        $schema->clearTableReadyForClass();
+        // Drop a table
+        DB::query(sprintf(
+            'DROP TABLE "%s";',
+            DataObject::getSchema()->baseDataTable(File::class)
+        ));
+        $this->assertFalse($schema->tablesAreReadyForClass(File::class), 'File table should NOT be ready after drop table');
+        $this->assertFalse($schema->tablesAreReadyForClass(Image::class), 'Image table should NOT be ready after drop table');
+        $this->assertFalse($schema->tablesAreReadyForClass(Folder::class), 'Folder table should NOT be ready after drop table');
+
+        // build the expected database schema and reset cache (fully reset so e.g. list of expected fields is pulled from extension)
+        static::resetDBSchema();
+        $schema->reset();
+        // Add an extension that adds new columns
+        Image::add_extension(AdditionalFieldsExtension::class);
+        $this->assertTrue($schema->tablesAreReadyForClass(File::class), 'File table should be ready after add extension');
+        $this->assertFalse($schema->tablesAreReadyForClass(Image::class), 'Image table should NOT be ready after add extension');
+        $this->assertTrue($schema->tablesAreReadyForClass(Folder::class), 'Folder table should be ready after add extension');
+
+        // build the expected database schema and reset cache
+        static::resetDBSchema();
+        $schema->clearTableReadyForClass();
+        // Should all be true again
+        $this->assertTrue($schema->tablesAreReadyForClass(File::class), 'File table should be ready at end');
+        $this->assertTrue($schema->tablesAreReadyForClass(Image::class), 'Image table should be ready at end');
+        $this->assertTrue($schema->tablesAreReadyForClass(Folder::class), 'Folder table should be ready at end');
     }
 }

--- a/tests/php/ORM/DataObjectSchemaTest/AdditionalFieldsExtension.php
+++ b/tests/php/ORM/DataObjectSchemaTest/AdditionalFieldsExtension.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class AdditionalFieldsExtension extends Extension implements TestOnly
+{
+    private static array $db = [
+        'SomeField' => 'Boolean',
+    ];
+}


### PR DESCRIPTION
This effectively makes the functionality from `Security::database_is_ready()` reusable for any arbitrary `DataObject` subclass.

Replaces #10276

I've resurrected this old PR because I was about to reimplement "is the DB ready?" checks _yet again_ in https://github.com/silverstripe/silverstripe-framework/pull/11783.... I'd much rather just reuse existing logic instead.

## Parent issue
- #10332
