### PR TITLE
FIX Correctly check merge option in i18n task

### DIFF
--- a/src/Dev/Tasks/i18nTextCollectorTask.php
+++ b/src/Dev/Tasks/i18nTextCollectorTask.php
@@ -55,9 +55,7 @@ class i18nTextCollectorTask extends BuildTask
      */
     protected function getIsMerge(InputInterface $input): bool
     {
-        $merge = $input->getOption('merge');
-        // merge=0 or merge=false will disable merge
-        return !in_array($merge, ['0', 'false']);
+        return (bool)$input->getOption('merge');
     }
 
     public function getOptions(): array
@@ -66,7 +64,7 @@ class i18nTextCollectorTask extends BuildTask
             new InputOption('locale', null, InputOption::VALUE_REQUIRED, 'Sets default locale'),
             new InputOption('writer', null, InputOption::VALUE_REQUIRED, 'Custom writer class (must implement the <info>SilverStripe\i18n\Messages\Writer</> interface)'),
             new InputOption('module', null, InputOption::VALUE_REQUIRED, 'One or more modules to limit collection (comma-separated)'),
-            new InputOption('merge', null, InputOption::VALUE_NEGATABLE, 'Merge new strings with existing ones already defined in language files', true),
+            new InputOption('merge', null, InputOption::VALUE_NEGATABLE, 'Merge new strings with existing ones already defined in language files <comment>[default: true]</comment>', true),
         ];
     }
 }


### PR DESCRIPTION
Updated getIsMerge to new NEGATABLE Input option logic.

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
The current sake implementation is broken and destroyed all existing translations.
However it worked via browser via dev/tasks

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11797 

## Manual testing steps
```sh
vendor/bin/sake tasks:i18nTextCollectorTask --locale=de --merge // Did not work before, did no merge
vendor/bin/sake tasks:i18nTextCollectorTask --locale=it --merge // Did not work before, did no merge
vendor/bin/sake tasks:i18nTextCollectorTask --locale=en --no-merge
```

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
