### PR TITLE
FIX #11788 Broken sort and missing column name escaping

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -970,7 +970,7 @@ abstract class Database
         $caseStatements = [];
         foreach ($values as $index => $value) {
             $escaped = is_int($value) ? $value : "'" . addslashes($value) . "'";
-            $caseStatements[] = "CASE {$field} = {$escaped} THEN {$index}";
+            $caseStatements[] = "WHEN \"{$field}\" = {$escaped} THEN {$index}";
         }
         $count = count($caseStatements);
         $sqlCase = implode(' ', $caseStatements);

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1382,7 +1382,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
                 // Only get joins relevant for the parent list
                 . '" WHERE "' . $parentIDField . '" IN (' . implode(',', $parentIDs) . ')'
                 // Exclude any children that got filtered out
-                . ' AND ' . $childIDField . ' IN (' . implode(',', $fetchedIDs) . ')'
+                . ' AND "' . $childIDField . '" IN (' . implode(',', $fetchedIDs) . ')'
                 // Respect sort order of fetched items
                 . ' ORDER BY ' . $orderByClause;
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->

### Description

I use postgres instead of mysql and tried to eagerLoad a many_many Relation.

That results into an sql error because the query does not escape some fields correctly and the sorting implentation is broken.

```
syntax error at or near "THEN" Couldn't run query: SELECT * FROM "Table" WHERE "MyID" IN (...) AND MyOtherID IN (...) ORDER BY CASE CASE MyOtherID = 114 THEN 0 CASE ...
```

### How to reproduce

```php
MyObject::get()->eagerLoad('ManyManyRelation')
````

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11788

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
