### PR TITLE
FIX Add null check to ClassInfo::hasTable.

### DIFF
--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -84,6 +84,9 @@ class ClassInfo implements Flushable
      */
     public static function hasTable($tableName)
     {
+        if (empty($tableName)) {
+            return false;
+        }
         $cache = ClassInfo::getCache();
         $configData = serialize(DB::getConfig());
         $cacheKey = 'tableList_' . md5($configData);

--- a/tests/php/Core/ClassInfoTest.php
+++ b/tests/php/Core/ClassInfoTest.php
@@ -4,7 +4,6 @@ namespace SilverStripe\Core\Tests;
 
 use DateTime;
 use Exception;
-use ReflectionException;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Tests\ClassInfoTest\BaseClass;
 use SilverStripe\Core\Tests\ClassInfoTest\BaseDataClass;
@@ -284,6 +283,14 @@ class ClassInfoTest extends SapphireTest
             $output,
             ClassInfo::hasMethod($object, $method)
         );
+    }
+
+    public function testHasTable()
+    {
+        $this->assertFalse(ClassInfo::hasTable(null));
+        $this->assertFalse(ClassInfo::hasTable(''));
+        $this->assertFalse(ClassInfo::hasTable('UnknownTableName'));
+        $this->assertTrue(ClassInfo::hasTable('Member'));
     }
 
     public function provideHasMethodCases()


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11790

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
