### PR TITLE
ENH Add indexes to member for autologin and CMS auth

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -117,8 +117,10 @@ class Member extends DataObject
 
     private static $indexes = [
         'Email' => true,
-        //Removed due to duplicate null values causing MSSQL problems
-        //'AutoLoginHash' => Array('type'=>'unique', 'value'=>'AutoLoginHash', 'ignoreNulls'=>true)
+        // Not a unique index due to duplicate null values causing MSSQL problems
+        'AutoLoginHash' => true,
+        'AutoLoginTempHash' => true,
+        'TempIDHash' => true,
     ];
 
     private static bool $require_sudo_mode = true;


### PR DESCRIPTION
Adds indexes for `AutoLoginHash` (and `AutoLoginTempHash`) and `TempIDHash` which are used for the "keep me logged in" and in-CMS re-authentication features respectively.

These are each used to find a record with a specific unique hash, so in tables with massive numbers of members this will be a dramatic improvement.

## Issues

- https://github.com/silverstripe/.github/issues/414
- https://github.com/silverstripe/silverstripe-framework/issues/11569
- https://github.com/silverstripe/silverstripe-framework/issues/11384