### PR TITLE
FIX `ArrayList::dataClass()` should give correct values for arrays

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -87,7 +87,13 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
             return $this->dataClass;
         }
         if (count($this->items ?? []) > 0) {
-            return get_class($this->items[0]);
+            $item = $this->items[array_key_first($this->items)];
+            if (is_array($item)) {
+                return ArrayData::class;
+            }
+            if (is_object($item)) {
+                return get_class($item);
+            }
         }
         return null;
     }

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -1832,14 +1832,44 @@ class ArrayListTest extends SapphireTest
         $this->assertNull($element);
     }
 
-    public function testDataClass()
+    public static function provideDataClass(): array
     {
-        $list = new ArrayList([
-            new DataObject(['Title' => 'one']),
-        ]);
-        $this->assertEquals(DataObject::class, $list->dataClass());
+        return [
+            'empty list' => [
+                'items' => [],
+                'expected' => null,
+            ],
+            'stdclass first in list' => [
+                'items' => [new stdClass(['Title' => 'one']), new stdClass(['Title' => 'two'])],
+                'expected' => stdClass::class,
+            ],
+            'associative array first in list' => [
+                'items' => [['Title' => 'one'], ['Title' => 'two']],
+                'expected' => ArrayData::class,
+            ],
+            'arbitrary stuff in list' => [
+                'items' => [1, 2, 3],
+                'expected' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataClass
+     */
+    public function testDataClass(array $items, ?string $expected): void
+    {
+        $list = new ArrayList($items);
+        $this->assertEquals($expected, $list->dataClass());
+        // removing item 1 shouldn't cause any problems
+        if (count($items) > 1) {
+            $list->remove($items[0]);
+            $this->assertEquals($expected, $list->dataClass());
+        }
+        // Removing the last item should mean we get `null` as a result
         $list->pop();
         $this->assertNull($list->dataClass());
+        // If we set an explicit value, even empty classes use the explicit value
         $list->setDataClass(DataObject::class);
         $this->assertEquals(DataObject::class, $list->dataClass());
     }


### PR DESCRIPTION
There were a few connected problems with this method:
1. Arrays weren't handled - they're wrapped in `ArrayData` in the iterator so that's the class we should report
2. If the 1st index of the items array wasn't 0 we'd get an error. Methods like `remove()` just unset the key from the array so could remove the 0 key
3. Non-array non-object values weren't correctly reporting that they're not a class.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11795