### PR TITLE
FIX Don't try to index TEXT data types

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -15,6 +15,7 @@ use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\Connect\DBSchemaManager;
 use SilverStripe\ORM\FieldType\DBComposite;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBText;
 
 /**
  * Provides dataobject and database schema mapping functionality
@@ -654,7 +655,12 @@ class DataObjectSchema
                     if ($table && strtolower($table ?? '') !== strtolower(DataObjectSchema::tableName($class) ?? '')) {
                         continue;
                     }
-                    if ($this->databaseField($class, $column, false)) {
+                    $fieldSpec = $this->databaseField($class, $column, false);
+                    if ($fieldSpec) {
+                        $dbField = Injector::inst()->create($fieldSpec, $column);
+                        if ($dbField instanceof DBText) {
+                            continue;
+                        }
                         $indexes[$column] = [
                             'type' => 'index',
                             'columns' => [$column],

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -329,6 +329,17 @@ class DataObjectSchemaGenerationTest extends SapphireTest
                 'defaultSort' => ['"Sort"' => 'DESC', '"Title"' => 'ASC'],
                 'expected' => ['Sort', 'Title'],
             ],
+            // DBText cannot be used in indexes
+            'a few different field types in sort' => [
+                'defaultSort' => [
+                    '"Sort"' => 'DESC',
+                    '"SomeDBText"' => 'DESC',
+                    '"SomeDBHtmlText"' => 'ASC',
+                    'SomeDBHtmlVarchar' => 'ASC',
+                    'Title' => 'ASC'
+                ],
+                'expected' => ['Sort', 'SomeDBHtmlVarchar', 'Title'],
+            ],
         ];
     }
 

--- a/tests/php/ORM/DataObjectSchemaGenerationTest/SortedObject.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest/SortedObject.php
@@ -12,6 +12,9 @@ class SortedObject extends DataObject implements TestOnly
     private static $db = [
         'Title' => 'Varchar',
         'Sort' => 'Int',
+        'SomeDBText' => 'Text',
+        'SomeDBHtmlText' => 'HTMLText',
+        'SomeDBHtmlVarchar' => 'HTMLVarchar',
     ];
 
     private static $default_sort = 'Sort';


### PR DESCRIPTION
We should probably make this configurable in CMS 6 for custom `DBField` implementations.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11778