### PR TITLE
FIX fix merge-up

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3863,7 +3863,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 if (is_string($joinSort) || is_array($joinSort)) {
                     $sortIndex = $schema->deriveIndexFromSort(
                         $tableOrClass,
-                        array_keys($manymanyFields),
+                        $manymanyFields,
                         $joinSort,
                         DataObjectSchema::SORT_INDEX_MODE_COMPOSITE
                     );

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -625,7 +625,21 @@ class DataObjectSchemaGenerationTest extends SapphireTest
                     'SomeDBHtmlVarchar' => 'ASC',
                     'Title' => 'ASC'
                 ],
-                'expectedIndexes' => ['Sort', 'SomeDBHtmlVarchar', 'Title'],
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'SomeDBHtmlVarchar' => [
+                        'type' => 'index',
+                        'columns' => ['SomeDBHtmlVarchar'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => null,
+                ],
             ],
         ];
     }


### PR DESCRIPTION
Fixes a bad merge-up

I forgot to apply these changes before committing [this merge-up](https://github.com/silverstripe/silverstripe-framework/commit/da0050f681b7eb12fb1cb95da71b4a4e1c0c15d5).

This PR:
1. fixes the format of the `provideSortFieldBecomesIndexes()` data provider - it may not actually pass the test, but the format is correct. Fixing the test if it is failing will be a separate follow-up PR. Fixing tests is not part of the merge-up, but updating the style of the provider to match the other scenarios is.
2. Removes `array_keys` call to match the other call to `DataObjectSchema::deriveIndexFromSort()`

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11778