### PR TITLE
FIX Don't skip-over columns for sort index.

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -778,6 +778,7 @@ class DataObjectSchema
                 $fieldSpec = $fields[$column];
                 $dbField = Injector::inst()->create($fieldSpec, $column);
                 if ($dbField instanceof DBText) {
+                    $shouldAddToComposite = false;
                     continue;
                 }
                 // Add indexes as appropriate

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -620,9 +620,9 @@ class DataObjectSchemaGenerationTest extends SapphireTest
             'a few different field types in sort' => [
                 'defaultSort' => [
                     '"Sort"' => 'DESC',
+                    'SomeDBHtmlVarchar' => 'ASC',
                     '"SomeDBText"' => 'DESC',
                     '"SomeDBHtmlText"' => 'ASC',
-                    'SomeDBHtmlVarchar' => 'ASC',
                     'Title' => 'ASC'
                 ],
                 'expectedIndexes' => [
@@ -638,7 +638,10 @@ class DataObjectSchemaGenerationTest extends SapphireTest
                         'type' => 'index',
                         'columns' => ['Title'],
                     ],
-                    'default_sort_composite' => null,
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort DESC', 'SomeDBHtmlVarchar ASC'],
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
MySQL (and probably others) can't skip over a column in an index, so any columns after the ommitted one aren't actually used and just increase database size with no benefit.

Note that this PR explicitly _does not_ add configuration or use prefixes for TEXT column types - that will be a follow-up enhancement following investigation as per https://github.com/silverstripe/silverstripe-framework/issues/11778#issuecomment-3111685748

For now I'm just fixing the existing behaviour. We have the beta in a few weeks so we should ideally try to keep the `6` branch in a good state.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11778