### PR TITLE
FIX Make backURL respect subdirectory path

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -649,7 +649,7 @@ class Director implements TemplateGlobalProvider
         // Check if BASE_SCRIPT_URL is defined
         // e.g. `index.php/`
         if (defined('BASE_SCRIPT_URL')) {
-            return $baseURL . BASE_SCRIPT_URL;
+            return rtrim($baseURL . BASE_SCRIPT_URL, '/') . '/';
         }
 
         return $baseURL;

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -415,7 +415,7 @@ class Security extends Controller implements TemplateGlobalProvider
         $message = $messageSet['default'];
 
         $request = $controller->getRequest();
-        $requestUrl = '/' . ltrim($request->getURL(true), '/');
+        $requestUrl = Director::baseURL() . ltrim($request->getURL(true), '/');
         if ($request->hasSession()) {
             list($messageText, $messageCast) = $parseMessage($message);
             static::singleton()->setSessionMessage($messageText, ValidationResult::TYPE_WARNING, $messageCast);

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -78,8 +78,28 @@ class SecurityTest extends FunctionalTest
         parent::tearDown();
     }
 
-    public function testAccessingAuthenticatedPageRedirectsToLoginForm()
+    public static function provideAccessingAuthenticatedPageRedirectsToLoginForm(): array
     {
+        return [
+            [
+                'baseUrl' => null,
+                'expectedBackUrl' => '/SecurityTest_SecuredController',
+            ],
+            [
+                'baseUrl' => 'https://www.example.com/subfolder',
+                'expectedBackUrl' => '/subfolder/SecurityTest_SecuredController',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideAccessingAuthenticatedPageRedirectsToLoginForm')]
+    public function testAccessingAuthenticatedPageRedirectsToLoginForm(?string $baseUrl, string $expectedBackUrl): void
+    {
+        if ($baseUrl) {
+            // We can't set `SS_BASE_URL` because that gets consumed to define the `BASE_URL` constant way before this point.
+            // Instead set alternate_base_url which at least checks the director logic is being used correctly.
+            Director::config()->set('alternate_base_url', $baseUrl);
+        }
         $this->autoFollowRedirection = false;
 
         $response = $this->get('SecurityTest_SecuredController');
@@ -88,6 +108,10 @@ class SecurityTest extends FunctionalTest
             Config::inst()->get(Security::class, 'login_url'),
             $response->getHeader('Location')
         );
+
+        parse_str(parse_url($response->getHeader('Location'), PHP_URL_QUERY), $query);
+        $this->assertArrayHasKey('BackURL', $query);
+        $this->assertSame($expectedBackUrl, $query['BackURL']);
 
         $this->logInWithPermission('ADMIN');
         $response = $this->get('SecurityTest_SecuredController');


### PR DESCRIPTION
I have also checked for other cases where the `backURL` query string gets set and those were all already using various ways to include the subdirectory in the path.

I can't find a sensible way to _directly_ test this, because the `SS_BASE_URL` environment variable is consumed to set the `BASE_URL` constant which happens during test bootstrapping, which is before I can get at it to update the test.

Instead I've opted to use `Director.alternate_base_url` which at least checks that `Director::baseURL()` is being used correctly here.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11769