### PR TITLE
NEW Allow filtering and excluding based on another list

### DIFF
--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -17,6 +17,7 @@ use SilverStripe\Model\ArrayData;
 use SilverStripe\View\SSViewer;
 use LogicException;
 use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\View\TemplateEngine;
 use SilverStripe\View\ViewLayerData;
@@ -278,8 +279,14 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
         }
 
         // Apply baseline filtering and limits which should hold regardless of any customisations
+        if (ClassInfo::hasMethod($results, 'excludeByList')) {
+            $results = $results->excludeByList($gridField->getList());
+        } elseif (ClassInfo::hasMethod($results, 'subtract')) {
+            $results = $results->subtract($gridField->getList());
+        } else {
+            $results = $results->exclude(['ID' => $gridField->getList()->column('ID')]);
+        }
         $results = $results
-            ->subtract($gridField->getList())
             ->filterAny($params)
             ->limit($this->getResultsLimit());
 

--- a/src/Forms/GridField/GridFieldGroupDeleteAction.php
+++ b/src/Forms/GridField/GridFieldGroupDeleteAction.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Core\Validation\ValidationException;
+use SilverStripe\ORM\DataList;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
@@ -86,21 +87,21 @@ class GridFieldGroupDeleteAction extends GridFieldDeleteAction
      */
     protected function canUnlink($record)
     {
+        // If the record isn't the current member or isn't an admin, don't allow unlinking.
         $currentUser = Security::getCurrentUser();
-        if ($currentUser
-            && $record instanceof Member
-            && (int)$record->ID === (int)$currentUser->ID
-            && Permission::checkMember($record, 'ADMIN')
+        if (!$currentUser
+            || !($record instanceof Member)
+            || (int)$record->ID !== (int)$currentUser->ID
+            || !Permission::checkMember($record, 'ADMIN')
         ) {
-            $adminGroups = array_intersect(
-                $record->Groups()->column() ?? [],
-                Permission::get_groups_by_permission('ADMIN')->column()
-            );
-
-            if (count($adminGroups ?? []) === 1 && array_search($this->groupID, $adminGroups ?? []) !== false) {
-                return false;
-            }
+            return false;
         }
+        // If there is exactly one admin group and it's THIS group, don't allow unlinking.
+        $adminGroups = $record->Groups()->filterByList(Permission::get_groups_by_permission('ADMIN'));
+        if ($adminGroups->count() === 1 && $adminGroups->filter(['ID' => $this->groupID])->exists()) {
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -485,6 +485,17 @@ abstract class Database
     }
 
     /**
+     * Generates a WHERE clause checking if two columns are equal, which
+     * also returns `1` if both values are null.
+     */
+    public function nullSafeEqualsClause(string $field1, string $field2): string
+    {
+        $nullField1 = $this->nullCheckClause($field1, true);
+        $nullField2 = $this->nullCheckClause($field2, true);
+        return "($field1 = $field2 OR ($nullField1 AND $nullField2))";
+    }
+
+    /**
      * Generate a WHERE clause for text matching.
      *
      * @param string $field Quoted field name

--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -429,6 +429,11 @@ class MySQLDatabase extends Database implements TransactionManager
         }
     }
 
+    public function nullSafeEqualsClause(string $field1, string $field2): string
+    {
+        return "$field1 <=> $field2";
+    }
+
     public function comparisonClause(
         $field,
         $value,

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -12,6 +12,7 @@ use LogicException;
 use BadMethodCallException;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\Connect\Query;
 use Traversable;
 use SilverStripe\ORM\DataQuery;
@@ -659,6 +660,22 @@ class DataList extends ModelData implements SS_List, Resettable
     }
 
     /**
+     * Return a copy of this list which only includes items where $fieldToFilterBy matches values in $fieldFromOtherList from $list.
+     *
+     * If both fields are ID, the $list dataclass must be in the same class hierarchy as the dataclass in this list
+     *
+     * @param SS_List<DataObject> $list
+     * @param string $fieldToFilterBy The name of the field in $this to filter by
+     * @param string $fieldFromOtherList The name of the field in $list to get filter values from
+     * @return static<T>
+     * @throws InvalidArgumentException
+     */
+    public function filterByList(SS_List $list, string $fieldToFilterBy = 'ID', string $fieldFromOtherList = 'ID'): static
+    {
+        return $this->filterOrExcludeByList($list, $fieldToFilterBy, $fieldFromOtherList, false);
+    }
+
+    /**
      * Given a field or relation name, apply it safely to this datalist.
      *
      * Unlike getRelationName, this is immutable and will fallback to the quoted field
@@ -800,6 +817,22 @@ class DataList extends ModelData implements SS_List, Resettable
     }
 
     /**
+     * Return a copy of this list which does not include items where $fieldToFilterBy matches values in $fieldFromOtherList from $list.
+     *
+     * If both fields are ID, the $list dataclass must be in the same class hierarchy as the dataclass in this list
+     *
+     * @param SS_List<DataObject> $list
+     * @param string $fieldToFilterBy The name of the field in $this to exclude by
+     * @param string $fieldFromOtherList The name of the field in $list to get exclude values from
+     * @return static<T>
+     * @throws InvalidArgumentException
+     */
+    public function excludeByList(SS_List $list, string $fieldToFilterBy = 'ID', string $fieldFromOtherList = 'ID'): static
+    {
+        return $this->filterOrExcludeByList($list, $fieldToFilterBy, $fieldFromOtherList, true);
+    }
+
+    /**
      * This method returns a copy of this list that does not contain any DataObjects that exists in $list
      *
      * The $list passed needs to contain the same dataclass as $this
@@ -807,16 +840,12 @@ class DataList extends ModelData implements SS_List, Resettable
      * @param DataList<DataObject> $list
      * @return static<T>
      * @throws InvalidArgumentException
+     * @deprecated 6.1.0 use excludeByList() instead.
      */
     public function subtract(DataList $list)
     {
-        if ($this->dataClass() != $list->dataClass()) {
-            throw new InvalidArgumentException('The list passed must have the same dataclass as this class');
-        }
-
-        return $this->alterDataQuery(function (DataQuery $query) use ($list) {
-            $query->subtract($list->dataQuery());
-        });
+        Deprecation::notice('6.1.0', 'Use excludeByList() instead.');
+        return $this->excludeByList($list);
     }
 
     /**
@@ -2166,5 +2195,53 @@ class DataList extends ModelData implements SS_List, Resettable
     {
         $ids = $this->column('ID');
         $this->extend('onPrepopulateCaches', $ids);
+    }
+
+    /**
+     * Shared logic for filterByList() and excludeByList()
+     */
+    private function filterOrExcludeByList(SS_List $list, string $fieldToFilterBy, string $fieldFromOtherList, bool $isExclude): static
+    {
+        $thisDataClass = $this->dataClass();
+        $listDataClass = $this->getDataClassFromList($list);
+        if ($fieldToFilterBy === 'ID'
+            && $fieldFromOtherList === 'ID'
+            && !is_a($thisDataClass, $listDataClass, true)
+            && !is_a($listDataClass, $thisDataClass, true)
+        ) {
+            throw new InvalidArgumentException('If both columns are ID, the $list dataclass must be in the same class hierarchy as the dataclass in this list');
+        }
+        // Try to filter/exclude by the list with a subquery for best performance
+        if ($list instanceof DataList) {
+            return $this->alterDataQuery(function (DataQuery $query) use ($list, $fieldToFilterBy, $fieldFromOtherList, $isExclude) {
+                if ($isExclude) {
+                    $query->excludeByQuery($list->dataQuery(), $fieldToFilterBy, $fieldFromOtherList);
+                } else {
+                    $query->filterByQuery($list->dataQuery(), $fieldToFilterBy, $fieldFromOtherList);
+                }
+            });
+        }
+        // Fall back to regular filtering/excluding
+        $columnFromList = $list->columnUnique($fieldFromOtherList);
+        if ($isExclude) {
+            return $this->exclude($fieldToFilterBy, $columnFromList);
+        }
+        return $this->filter($fieldToFilterBy, $columnFromList);
+    }
+
+    /**
+     * Get the class of items that the list holds, or null for lists with non-objects
+     */
+    private function getDataClassFromList(SS_List $list): ?string
+    {
+        if (ClassInfo::hasMethod($list, 'dataClass')) {
+            return $list->dataClass();
+        }
+        // Assume all items in the list have the same class, like ArrayList does.
+        $item = $list->first();
+        if (is_object($item)) {
+            return get_class($item);
+        }
+        return null;
     }
 }

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -12,6 +12,8 @@ use SilverStripe\ORM\Queries\SQLSelect;
 use InvalidArgumentException;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\Security\RandomGenerator;
 
 /**
  * An object representing a query of data from the DataObject's supporting database.
@@ -820,6 +822,28 @@ class DataQuery implements Resettable
     }
 
     /**
+     * Filters the query where $fieldToFilterBy matches values in $fieldFromOtherList from $subQuery.
+     *
+     * @param string $fieldToFilterBy The name of the column in the current query to filter by
+     * @param string $fieldFromOtherList The name of the column in $subQuery to get filter values from
+     */
+    public function filterByQuery(DataQuery $subQuery, string $fieldToFilterBy = 'ID', string $fieldFromOtherList = 'ID'): static
+    {
+        return $this->filterOrExcludeByQuery($subQuery, false, $fieldToFilterBy, $fieldFromOtherList);
+    }
+
+    /**
+     * Excludes records in the query where $fieldToFilterBy matches values in $fieldFromOtherList from $subQuery.
+     *
+     * @param string $fieldToFilterBy The name of the column in the current query to filter by
+     * @param string $fieldFromOtherList The name of the column in $subQuery to get filter values from
+     */
+    public function excludeByQuery(DataQuery $subQuery, string $fieldToFilterBy = 'ID', string $fieldFromOtherList = 'ID'): static
+    {
+        return $this->filterOrExcludeByQuery($subQuery, true, $fieldToFilterBy, $fieldFromOtherList);
+    }
+
+    /**
      * Set the ORDER BY clause of this query
      *
      * Note: while the similarly named DataList::sort() does not allow raw SQL, DataQuery::sort() does allow it
@@ -1271,18 +1295,12 @@ class DataQuery implements Resettable
      * @param DataQuery $subtractQuery
      * @param string $field
      * @return $this
+     * @deprecated 6.1.0 use excludeByQuery() instead.
      */
     public function subtract(DataQuery $subtractQuery, $field = 'ID')
     {
-        $fieldExpression = $subtractQuery->expressionForField($field);
-        $subSelect = $subtractQuery->getFinalisedQuery();
-        $subSelect->setSelect([]);
-        $subSelect->selectField($fieldExpression, $field);
-        $subSelect->setOrderBy(null);
-        $subSelectSQL = $subSelect->sql($subSelectParameters);
-        $this->where([$this->expressionForField($field) . " NOT IN ($subSelectSQL)" => $subSelectParameters]);
-
-        return $this;
+        Deprecation::notice('6.1.0', 'Use excludeByQuery() instead.');
+        return $this->excludeByQuery($subtractQuery, $field, $field);
     }
 
     /**
@@ -1554,5 +1572,44 @@ class DataQuery implements Resettable
             return DB::withPrimary($callback);
         }
         return $callback();
+    }
+
+    private function filterOrExcludeByQuery(DataQuery $subQuery, bool $isExclude, string $fieldToFilterBy, string $fieldFromOtherList): static
+    {
+        if ($fieldFromOtherList === '' || $fieldToFilterBy === '') {
+            throw new InvalidArgumentException('$fieldToFilterBy and $fieldFromOtherList must not be empty strings');
+        }
+        $subSelect = $subQuery->getFinalisedQuery();
+        // Select only the relevant field, and ID. The ID is used below to validate the join.
+        $subSelect->setSelect([]);
+        $subSelect->selectField($subQuery->expressionForField($fieldFromOtherList), $fieldFromOtherList);
+        $subSelect->selectField($subQuery->expressionForField('ID'), 'ID');
+        // Remove order so the database can use whatever order is most efficient.
+        $subSelect->setOrderBy(null);
+
+        // Alias has to be unique so it doesn't conflict with another alias generated on the same query.
+        // A conflict is very unlikely but it's better to be 100% sure rather than having intermittent failures.
+        $from = $this->query->getFrom();
+        $subQueryAlias = null;
+        do {
+            // md5 is fast and very unlikely to have conflicts in this scenario.
+            $subQueryAlias = 'subQueryAlias' . RandomGenerator::singleton()->randomToken('md5');
+        } while (array_key_exists($subQueryAlias, $from));
+        // TL;DR: join on to the subquery works here while WHERE on its own would be complex to handle in an elegant way.
+        // Lengthy explanation:
+        // Join onto the subquery - this is more robust than adding it as a WHERE clause because it allows us to use an alias
+        // which protects us from errors if this method is called multiple times.
+        // We can't just do a straight "WHERE NOT IN (<subquery>)" because that doesn't account for null values, so any if we
+        // wanted to do that we'd need to use WHERE NOT EXISTS IN (<altered subquery>) where the altered subquery needs to check
+        // if the parent query $fieldToFilterBy is null-safe-equals to the subquery $fieldToFilterBy, and if both queries are on
+        // the same table that REQUIRES an alias to be used.
+        $subSelectSQL = $subSelect->sql($subSelectParameters);
+        $filterByExpression = $this->expressionForField($fieldToFilterBy);
+        $on = DB::get_conn()->nullSafeEqualsClause($filterByExpression, Convert::symbol2sql("{$subQueryAlias}.{$fieldFromOtherList}"));
+        $this->leftJoin('(' . $subSelectSQL . ')', $on, $subQueryAlias, parameters: $subSelectParameters);
+
+        // This WHERE clause is required to distinguish between a join with no results and a join where $fieldFromOtherList is NULL.
+        $this->where(DB::get_conn()->nullCheckClause(Convert::symbol2sql("{$subQueryAlias}.ID"), $isExclude));
+        return $this;
     }
 }

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -10,6 +10,8 @@ use BadMethodCallException;
 use InvalidArgumentException;
 use LogicException;
 use SilverStripe\Core\ArrayLib;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Model\List\Map;
 use SilverStripe\Model\List\SS_List;
@@ -503,6 +505,22 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
         return $list;
     }
 
+    /**
+     * Return a copy of this list which only includes items where $fieldToFilterBy matches values in $fieldFromOtherList from $list.
+     *
+     * If both fields are ID, the $list dataclass must be in the same class hierarchy as the dataclass in this list
+     *
+     * @param SS_List<DataObject> $list
+     * @param string $fieldToFilterBy The name of the field in $this to filter by
+     * @param string $fieldFromOtherList The name of the field in $list to get filter values from
+     * @return static<T>
+     * @throws InvalidArgumentException
+     */
+    public function filterByList(SS_List $list, string $fieldToFilterBy = 'ID', string $fieldFromOtherList = 'ID'): static
+    {
+        return $this->filterOrExcludeByList($list, $fieldToFilterBy, $fieldFromOtherList, false);
+    }
+
     public function exclude(...$args): static
     {
         $filters = $this->normaliseFilterArgs($args, __FUNCTION__);
@@ -531,6 +549,22 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
     }
 
     /**
+     * Return a copy of this list which does not include items where $fieldToFilterBy matches values in $fieldFromOtherList from $list.
+     *
+     * If both fields are ID, the $list dataclass must be in the same class hierarchy as the dataclass in this list
+     *
+     * @param SS_List<DataObject> $list
+     * @param string $fieldToFilterBy The name of the field in $this to exclude by
+     * @param string $fieldFromOtherList The name of the field in $list to get exclude values from
+     * @return static<T>
+     * @throws InvalidArgumentException
+     */
+    public function excludeByList(SS_List $list, string $fieldToFilterBy = 'ID', string $fieldFromOtherList = 'ID'): static
+    {
+        return $this->filterOrExcludeByList($list, $fieldToFilterBy, $fieldFromOtherList, true);
+    }
+
+    /**
      * Return a new instance of the list with an added filter
      *
      * @param array $filterArray
@@ -550,9 +584,11 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
      *
      * @return static<T>
      * @throws InvalidArgumentException
+     * @deprecated 6.1.0 use excludeByList() instead.
      */
     public function subtract(DataList $list): static
     {
+        Deprecation::notice('6.1.0', 'Use excludeByList() instead.');
         if ($this->dataClass() != $list->dataClass()) {
             throw new InvalidArgumentException('The list passed must have the same dataclass as this class');
         }
@@ -1025,5 +1061,42 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
     private function isNumericNotString(mixed $value): bool
     {
         return is_numeric($value) && !is_string($value);
+    }
+
+    /**
+     * Get the class of items that the list holds, or null for lists with non-objects
+     */
+    private function getDataClassFromList(SS_List $list): ?string
+    {
+        if (ClassInfo::hasMethod($list, 'dataClass')) {
+            return $list->dataClass();
+        }
+        // Assume all items in the list have the same class, like ArrayList does.
+        $item = $list->first();
+        if (is_object($item)) {
+            return get_class($item);
+        }
+        return null;
+    }
+
+    /**
+     * Shared logic for filterByList() and excludeByList()
+     */
+    private function filterOrExcludeByList(SS_List $list, string $fieldToFilterBy, string $fieldFromOtherList, bool $isExclude): static
+    {
+        $thisDataClass = $this->dataClass();
+        $listDataClass = $this->getDataClassFromList($list);
+        if ($fieldToFilterBy === 'ID'
+            && $fieldFromOtherList === 'ID'
+            && !is_a($thisDataClass, $listDataClass, true)
+            && !is_a($listDataClass, $thisDataClass, true)
+        ) {
+            throw new InvalidArgumentException('If both columns are ID, the $list dataclass must be in the same class hierarchy as the dataclass in this list');
+        }
+        $columnFromList = $list->columnUnique($fieldFromOtherList);
+        if ($isExclude) {
+            return $this->exclude($fieldToFilterBy, $columnFromList);
+        }
+        return $this->filter($fieldToFilterBy, $columnFromList);
     }
 }

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -10,6 +10,7 @@ use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Model\List\SS_List;
+use SilverStripe\ORM\DataQuery;
 use SilverStripe\View\TemplateGlobalProvider;
 
 /**
@@ -290,36 +291,42 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      */
     public static function permissions_for_member($memberID)
     {
-        $groupList = Permission::groupList($memberID);
+        $groupIDs = Permission::groupList($memberID);
 
-        if ($groupList) {
-            $groupCSV = implode(", ", $groupList);
+        if ($groupIDs) {
+            // Get the allowed permissions for this user based on the permissions assigned
+            // directly to its groups, and the permissions assigned to roles on its groups.
+            $allowed = Permission::get()
+                ->filter([
+                    'Type' => Permission::GRANT_PERMISSION,
+                    'GroupID' => $groupIDs,
+                ])
+                ->alterDataQuery(function (DataQuery $query) use ($groupIDs) {
+                    $schema = DataObject::getSchema();
+                    // These permissions are explicitly NOT allowed and
+                    // need to be excluded from the PermissionRoleCode set
+                    $denied = Permission::get()->filter([
+                        'Type' => Permission::DENY_PERMISSION,
+                        'GroupID' => $groupIDs,
+                    ]);
 
-            $allowed = array_unique(
-                DB::withPrimary(fn() => DB::query("
-                    SELECT \"Code\"
-                    FROM \"Permission\"
-                    WHERE \"Type\" = " . Permission::GRANT_PERMISSION . " AND \"GroupID\" IN ($groupCSV)
+                    // Get permission codes from roles these groups are assigned to, exluding the denied list above.
+                    $permissionRoleCodes = PermissionRoleCode::get()
+                        ->filter(['GroupID' => $groupIDs])
+                        ->excludeByList($denied, 'Code', 'Code')
+                        // Apply necessary joins
+                        ->applyRelation('Role.Groups.ID');
 
-                    UNION
+                    // Get the SQLSelect for the query so we can set it to explicitly only fetch the "Codes" column
+                    // Then union the queries together so we have PermissionRoleCode.Code and Permission.Code together.
+                    $permissionRoleCodes = $permissionRoleCodes->dataQuery()->query()->setSelect(
+                        $schema->sqlColumnForField(PermissionRoleCode::class, 'Code')
+                    );
+                    return $query->union($permissionRoleCodes);
+                });
 
-                    SELECT \"Code\"
-                    FROM \"PermissionRoleCode\" PRC
-                    INNER JOIN \"PermissionRole\" PR ON PRC.\"RoleID\" = PR.\"ID\"
-                    INNER JOIN \"Group_Roles\" GR ON GR.\"PermissionRoleID\" = PR.\"ID\"
-                    WHERE \"GroupID\" IN ($groupCSV)
-                "))->column() ?? []
-            );
-
-            $denied = array_unique(
-                DB::withPrimary(fn() => DB::query("
-                    SELECT \"Code\"
-                    FROM \"Permission\"
-                    WHERE \"Type\" = " . Permission::DENY_PERMISSION . " AND \"GroupID\" IN ($groupCSV)
-                "))->column() ?? []
-            );
-
-            return array_diff($allowed ?? [], $denied);
+            // Return all unique allowed permission codes for this member
+            return $allowed->columnUnique('Code');
         }
 
         return [];
@@ -350,26 +357,15 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
         }
 
         if ($member) {
-            // Build a list of the IDs of the groups.  Most of the heavy lifting
-            // is done by Member::Groups
-            // NOTE: This isn't efficient; but it's called once per session so
-            // it's a low priority to fix.
-            $groups = $member->Groups();
-            $groupList = [];
-
-            if ($groups) {
-                foreach ($groups as $group) {
-                    $groupList[] = $group->ID;
-                }
-            }
-
+            // Build a list of the IDs of the groups.
+            $groupIDs = $member->Groups()->column();
 
             // Session caching
             if (!$memberID) {
-                $_SESSION['Permission_groupList'][$member->ID] = $groupList;
+                $_SESSION['Permission_groupList'][$member->ID] = $groupIDs;
             }
 
-            return isset($groupList) ? $groupList : null;
+            return $groupIDs;
         }
         return null;
     }

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -36,18 +36,29 @@ use SilverStripe\ORM\Tests\DataObjectTest\RelationChildSecond;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\CliDebugView;
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\ORM\Tests\DataListTest\ChildModel;
+use SilverStripe\ORM\Tests\DataListTest\ParentModel;
+use SilverStripe\ORM\Tests\DataListTest\SeparateModel;
 
 class DataListTest extends SapphireTest
 {
-
-    // Borrow the model from DataObjectTest
-    protected static $fixture_file = 'DataObjectTest.yml';
+    protected static $fixture_file = [
+        'DataListTest.yml',
+        // Borrow the model from DataObjectTest
+        'DataObjectTest.yml',
+    ];
 
     public static function getExtraDataObjects()
     {
         return array_merge(
             DataObjectTest::$extra_data_objects,
-            ManyManyListTest::$extra_data_objects
+            ManyManyListTest::$extra_data_objects,
+            [
+                ParentModel::class,
+                ChildModel::class,
+                SeparateModel::class,
+            ],
         );
     }
 
@@ -201,6 +212,330 @@ class DataListTest extends SapphireTest
         $queryCounter->stopCounting();
         // First time through isn't cached
         $this->assertSame(0, $queryCounter->getCount());
+    }
+
+    public static function provideExcludeByList(): array
+    {
+        return [
+            'exclude by the whole list' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => [],
+                ],
+                'fieldToFilterBy' => 'ID',
+                'fieldFromOtherList' => 'ID',
+                'expectedFixtures' => [],
+            ],
+            'exclude by reduced set' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ID',
+                'fieldFromOtherList' => 'ID',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent2', 'parent4', 'parent5'],
+                    ChildModel::class => ['child2', 'child4'],
+                ],
+            ],
+            'exclude by empty list' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => 'Not a valid title'],
+                ],
+                'fieldToFilterBy' => 'ID',
+                'fieldFromOtherList' => 'ID',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent2', 'parent3', 'parent4', 'parent5'],
+                    ChildModel::class => ['child1', 'child2', 'child3', 'child4'],
+                ],
+            ],
+            'exclude by non-ID field' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent4', 'parent5'],
+                    ChildModel::class => ['child4'],
+                ],
+            ],
+            'exclude by field with null value' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['Five']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent2', 'parent3', 'parent4'],
+                    ChildModel::class => ['child1', 'child2', 'child3', 'child4'],
+                ],
+            ],
+            'exclude across class hierarchy' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ChildModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent3', 'parent4', 'parent5'],
+                    ChildModel::class => ['child2', 'child4'],
+                ],
+            ],
+            'exclude across class hierarchy, child is main list' => [
+                'list1Class' => ChildModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ChildModel::class => ['child4'],
+                ],
+            ],
+            'exclude across different classes' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => SeparateModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'SeparateField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent4', 'parent5'],
+                    ChildModel::class => ['child3', 'child4'],
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideExcludeByList')]
+    public function testExcludeByList(string $list1Class, array $list2Spec, string $fieldToFilterBy, string $fieldFromOtherList, array $expectedFixtures): void
+    {
+        $list1 = new DataList($list1Class);
+        $list2 = new DataList($list2Spec['class']);
+        if (!empty($list2Spec['pre-filters'])) {
+            $list2 = $list2->filter($list2Spec['pre-filters']);
+        }
+        $list1 = $list1->excludeByList($list2, $fieldToFilterBy, $fieldFromOtherList);
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    #[DataProvider('provideExcludeByList')]
+    public function testExcludeByListArrayList(string $list1Class, array $list2Spec, string $fieldToFilterBy, string $fieldFromOtherList, array $expectedFixtures): void
+    {
+        $list1 = new DataList($list1Class);
+        $list2 = new DataList($list2Spec['class']);
+        if (!empty($list2Spec['pre-filters'])) {
+            $list2 = $list2->filter($list2Spec['pre-filters']);
+        }
+        $list2 = new ArrayList($list2->toArray());
+        if (!$list2->dataClass()) {
+            $list2->setDataClass($list2Spec['class']);
+        }
+        if ($list2->count() === 0) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessageMatches('/^Cannot filter "[a-zA-Z0-9_]+"\."[a-zA-Z0-9_]+" against an empty set$/');
+        }
+        $list1 = $list1->excludeByList($list2, $fieldToFilterBy, $fieldFromOtherList);
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testExcludeByListMultipleCalls(): void
+    {
+        $expectedFixtures = [
+            ParentModel::class => ['parent1', 'parent3', 'parent4'],
+            ChildModel::class => ['child4'],
+        ];
+        $list1 = new DataList(ParentModel::class);
+        $list2 = (new DataList(ParentModel::class))->filter(['Title' => ['Two', 'Five']]);
+        $list3 = (new DataList(ChildModel::class))->filter(['Title' => ['One', 'Three']]);
+
+        // Make a chain of exclusions
+        $list1 = $list1->excludeByList($list3, 'ParentField', 'ParentField');
+        $list1 = $list1->excludeByList($list2);
+
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testExcludeByListBadDataclassThrowsException(): void
+    {
+        $teamsComments = TeamComment::get();
+        $teams = Team::get();
+        $this->expectException(InvalidArgumentException::class);
+        $teamsComments->excludeByList($teams);
+    }
+
+    public static function provideFilterByList(): array
+    {
+        return [
+            'filter by the whole list' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => [],
+                ],
+                'fieldToFilterBy' => 'ID',
+                'fieldFromOtherList' => 'ID',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent2', 'parent3', 'parent4', 'parent5'],
+                    ChildModel::class => ['child1', 'child2', 'child3', 'child4'],
+                ],
+            ],
+            'filter by reduced set' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ID',
+                'fieldFromOtherList' => 'ID',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent3'],
+                    ChildModel::class => ['child1', 'child3'],
+                ],
+            ],
+            'filter by empty list' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => 'Not a valid title'],
+                ],
+                'fieldToFilterBy' => 'ID',
+                'fieldFromOtherList' => 'ID',
+                'expectedFixtures' => [],
+            ],
+            'filter by non-ID field' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent1', 'parent2', 'parent3'],
+                    ChildModel::class => ['child1', 'child2', 'child3'],
+                ],
+            ],
+            'filter by field with null value' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['Five']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent5'],
+                ],
+            ],
+            'filter across class hierarchy' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => ChildModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent2'],
+                    ChildModel::class => ['child1', 'child3'],
+                ],
+            ],
+            'filter across class hierarchy, child is main list' => [
+                'list1Class' => ChildModel::class,
+                'list2Spec' => [
+                    'class' => ParentModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'ParentField',
+                'expectedFixtures' => [
+                    ChildModel::class => ['child1', 'child2', 'child3'],
+                ],
+            ],
+            'filter across different classes' => [
+                'list1Class' => ParentModel::class,
+                'list2Spec' => [
+                    'class' => SeparateModel::class,
+                    'pre-filters' => ['Title' => ['One', 'Three']],
+                ],
+                'fieldToFilterBy' => 'ParentField',
+                'fieldFromOtherList' => 'SeparateField',
+                'expectedFixtures' => [
+                    ParentModel::class => ['parent2', 'parent3'],
+                    ChildModel::class => ['child1', 'child2'],
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideFilterByList')]
+    public function testFilterByList(string $list1Class, array $list2Spec, string $fieldToFilterBy, string $fieldFromOtherList, array $expectedFixtures): void
+    {
+        $list1 = new DataList($list1Class);
+        $list2 = new DataList($list2Spec['class']);
+        if (!empty($list2Spec['pre-filters'])) {
+            $list2 = $list2->filter($list2Spec['pre-filters']);
+        }
+        $list1 = $list1->filterByList($list2, $fieldToFilterBy, $fieldFromOtherList);
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    #[DataProvider('provideFilterByList')]
+    public function testFilterByListArrayList(string $list1Class, array $list2Spec, string $fieldToFilterBy, string $fieldFromOtherList, array $expectedFixtures): void
+    {
+        $list1 = new DataList($list1Class);
+        $list2 = new DataList($list2Spec['class']);
+        if (!empty($list2Spec['pre-filters'])) {
+            $list2 = $list2->filter($list2Spec['pre-filters']);
+        }
+        $list2 = new ArrayList($list2->toArray());
+        if (!$list2->dataClass()) {
+            $list2->setDataClass($list2Spec['class']);
+        }
+        if ($list2->count() === 0) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessageMatches('/^Cannot filter "[a-zA-Z0-9_]+"\."[a-zA-Z0-9_]+" against an empty set$/');
+        }
+        $list1 = $list1->filterByList($list2, $fieldToFilterBy, $fieldFromOtherList);
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testFilterByListMultipleCalls(): void
+    {
+        $expectedFixtures = [
+            ParentModel::class => ['parent2'],
+        ];
+        $list1 = new DataList(ParentModel::class);
+        $list2 = (new DataList(ParentModel::class))->filter(['Title' => ['Two', 'Five']]);
+        $list3 = (new DataList(ChildModel::class))->filter(['ParentField' => 'Match child1 ParentField']);
+
+        // Make a chain of filters
+        $list1 = $list1->filterByList($list3, 'ParentField', 'ParentField');
+        $list1 = $list1->filterByList($list2);
+
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testFilterByListBadDataclassThrowsException(): void
+    {
+        $teamsComments = TeamComment::get();
+        $teams = Team::get();
+        $this->expectException(InvalidArgumentException::class);
+        $teamsComments->filterByList($teams);
     }
 
     public function testSetDataQuery(): void
@@ -3226,5 +3561,21 @@ class DataListTest extends SapphireTest
 
         $this->assertEmpty($expectedIDs, 'chunk returns all the results that the regular iterator does');
         $this->assertEquals($expectedQueryCount, $queryCounter->getCount());
+    }
+
+    /**
+     * Used by testExcludeByList* and testFilterByList* tests
+     */
+    private function assertFilterOrExcludeExpectedFixtures(DataList $list, array $expectedFixtures): void
+    {
+        $result = $list->column();
+        $numExpected = 0;
+        foreach ($expectedFixtures as $fixtureClass => $fixtureNames) {
+            foreach ($fixtureNames as $fixtureName) {
+                $numExpected++;
+                $this->assertContains($this->idFromFixture($fixtureClass, $fixtureName), $result, "looking for fixture $fixtureName");
+            }
+        }
+        $this->assertCount($numExpected, $result, 'contents: ' . implode(', ', $result));
     }
 }

--- a/tests/php/ORM/DataListTest.yml
+++ b/tests/php/ORM/DataListTest.yml
@@ -1,0 +1,48 @@
+# New fixtures that apply explicitly to DataListTest should be added here, so they don't interfer with DataObjectTest.
+# See also DataObjectTest.yml which is used in DataListTest.php
+SilverStripe\ORM\Tests\DataListTest\ParentModel:
+  parent1:
+    Title: 'One'
+    ParentField: 'Match child2 ChildField'
+  parent2:
+    Title: 'Two'
+    ParentField: 'Match child1 ParentField'
+  parent3:
+    Title: 'Three'
+    ParentField: 'Match child2 ParentField'
+  parent4:
+    Title: 'Four'
+    ParentField: 'Match separate2 SeparateField'
+  parent5:
+    Title: 'Five'
+    ParentField: null
+
+SilverStripe\ORM\Tests\DataListTest\ChildModel:
+  child1:
+    Title: 'One'
+    ParentField: 'Match child1 ParentField'
+    ChildField: 'Child field value'
+  child2:
+    Title: 'Two'
+    ParentField: 'Match child2 ParentField'
+    ChildField: 'Match child2 ChildField'
+  child3:
+    Title: 'Three'
+    ParentField: 'Parent field value'
+    ChildField: 'Child field value'
+  child4:
+    Title: 'Four'
+    ParentField: 'Another field value'
+    ChildField: 'Child field value'
+
+
+SilverStripe\ORM\Tests\DataListTest\SeparateModel:
+  separate1:
+    Title: 'One'
+    SeparateField: 'Match child2 ParentField'
+  separate2:
+    Title: 'Two'
+    SeparateField: 'Match separate2 SeparateField'
+  separate3:
+    Title: 'Three'
+    SeparateField: 'Match child1 ParentField'

--- a/tests/php/ORM/DataListTest/ChildModel.php
+++ b/tests/php/ORM/DataListTest/ChildModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataListTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class ChildModel extends ParentModel implements TestOnly
+{
+    private static string $table_name = 'DataListTest_ChildModel';
+
+    private static array $db = [
+        'ChildField' => 'Varchar',
+    ];
+}

--- a/tests/php/ORM/DataListTest/ParentModel.php
+++ b/tests/php/ORM/DataListTest/ParentModel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataListTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ParentModel extends DataObject implements TestOnly
+{
+    private static string $table_name = 'DataListTest_ParentModel';
+
+    private static array $db = [
+        'Title' => 'Varchar',
+        'ParentField' => 'Varchar',
+    ];
+}

--- a/tests/php/ORM/DataListTest/SeparateModel.php
+++ b/tests/php/ORM/DataListTest/SeparateModel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataListTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class SeparateModel extends DataObject implements TestOnly
+{
+    private static string $table_name = 'DataListTest_SeparateModel';
+
+    private static array $db = [
+        'Title' => 'Varchar',
+        'SeparateField' => 'Varchar',
+    ];
+}

--- a/tests/php/ORM/EagerLoadedListTest.php
+++ b/tests/php/ORM/EagerLoadedListTest.php
@@ -32,11 +32,18 @@ use SilverStripe\ORM\ManyManyThroughList;
 use SilverStripe\ORM\Tests\DataObjectTest\RelationChildFirst;
 use SilverStripe\ORM\Tests\DataObjectTest\RelationChildSecond;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use SilverStripe\ORM\Tests\DataListTest\ChildModel;
+use SilverStripe\ORM\Tests\DataListTest\ParentModel;
 
 class EagerLoadedListTest extends SapphireTest
 {
-    // Borrow the model from DataObjectTest
-    protected static $fixture_file = 'DataObjectTest.yml';
+    protected static $fixture_file = [
+        // Borrow the fixtures from DataListTest
+        'DataListTest.yml',
+        // Borrow the fixtures from DataObjectTest
+        'DataObjectTest.yml',
+    ];
 
     public static function getExtraDataObjects()
     {
@@ -2317,5 +2324,102 @@ class EagerLoadedListTest extends SapphireTest
             $result
         );
         $this->assertStringEndsWith('</ul>', $result);
+    }
+
+    #[DataProviderExternal(DataListTest::class, 'provideExcludeByList')]
+    public function testExcludeByList(string $list1Class, array $list2Spec, string $fieldToFilterBy, string $fieldFromOtherList, array $expectedFixtures): void
+    {
+        $list1 = $this->getListWithRecords(new DataList($list1Class));
+        $list2 = $this->getListWithRecords(new DataList($list2Spec['class']));
+        if (!empty($list2Spec['pre-filters'])) {
+            $list2 = $list2->filter($list2Spec['pre-filters']);
+        }
+        if ($list2->count() === 0) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage("Cannot filter $fieldToFilterBy against an empty set");
+        }
+        $list1 = $list1->excludeByList($list2, $fieldToFilterBy, $fieldFromOtherList);
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testExcludeByListMultipleCalls(): void
+    {
+        $expectedFixtures = [
+            ParentModel::class => ['parent1', 'parent3', 'parent4'],
+            ChildModel::class => ['child4'],
+        ];
+        $list1 = $this->getListWithRecords(new DataList(ParentModel::class));
+        $list2 = $this->getListWithRecords((new DataList(ParentModel::class))->filter(['Title' => ['Two', 'Five']]));
+        $list3 = $this->getListWithRecords((new DataList(ChildModel::class))->filter(['Title' => ['One', 'Three']]));
+
+        // Make a chain of exclusions
+        $list1 = $list1->excludeByList($list3, 'ParentField', 'ParentField');
+        $list1 = $list1->excludeByList($list2);
+
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testExcludeByListBadDataclassThrowsException(): void
+    {
+        $teamsComments = $this->getListWithRecords(TeamComment::get());
+        $teams = $this->getListWithRecords(Team::get());
+        $this->expectException(InvalidArgumentException::class);
+        $teamsComments->excludeByList($teams);
+    }
+
+    #[DataProviderExternal(DataListTest::class, 'provideFilterByList')]
+    public function testFilterByList(string $list1Class, array $list2Spec, string $fieldToFilterBy, string $fieldFromOtherList, array $expectedFixtures): void
+    {
+        $list1 = $this->getListWithRecords(new DataList($list1Class));
+        $list2 = $this->getListWithRecords(new DataList($list2Spec['class']));
+        if (!empty($list2Spec['pre-filters'])) {
+            $list2 = $list2->filter($list2Spec['pre-filters']);
+        }
+        if ($list2->count() === 0) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage("Cannot filter $fieldToFilterBy against an empty set");
+        }
+        $list1 = $list1->filterByList($list2, $fieldToFilterBy, $fieldFromOtherList);
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testFilterByListMultipleCalls(): void
+    {
+        $expectedFixtures = [
+            ParentModel::class => ['parent2'],
+        ];
+        $list1 = $this->getListWithRecords(new DataList(ParentModel::class));
+        $list2 = $this->getListWithRecords((new DataList(ParentModel::class))->filter(['Title' => ['Two', 'Five']]));
+        $list3 = $this->getListWithRecords((new DataList(ChildModel::class))->filter(['ParentField' => 'Match child1 ParentField']));
+
+        // Make a chain of filters
+        $list1 = $list1->filterByList($list3, 'ParentField', 'ParentField');
+        $list1 = $list1->filterByList($list2);
+
+        $this->assertFilterOrExcludeExpectedFixtures($list1, $expectedFixtures);
+    }
+
+    public function testFilterByListBadDataclassThrowsException(): void
+    {
+        $teamsComments = $this->getListWithRecords(TeamComment::get());
+        $teams = $this->getListWithRecords(Team::get());
+        $this->expectException(InvalidArgumentException::class);
+        $teamsComments->filterByList($teams);
+    }
+
+    /**
+     * Used by testExcludeByList* and testFilterByList* tests
+     */
+    private function assertFilterOrExcludeExpectedFixtures(EagerLoadedList $list, array $expectedFixtures): void
+    {
+        $result = $list->column();
+        $numExpected = 0;
+        foreach ($expectedFixtures as $fixtureClass => $fixtureNames) {
+            foreach ($fixtureNames as $fixtureName) {
+                $numExpected++;
+                $this->assertContains($this->idFromFixture($fixtureClass, $fixtureName), $result, "looking for fixture $fixtureName");
+            }
+        }
+        $this->assertCount($numExpected, $result, 'contents: ' . implode(', ', $result));
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> There are multiple commits. DO NOT SQUASH
> 1. Introduce the new API and deprecate old API
> 2. Start using the new methods where possible to reduce the number of queries
> 3. Replace usages of deprecated methods with the new replacements

This provides a convenient shortcut for e.g. filtering a list of pages by the IDs of a relation, where the relation IDs come from a separate pre-filtered query.

Using this instead of executing the first query and filtering by IDs (or by other fields) allows the database optimiser to optimise a joint query and reduces latency overhead of performing separate queries.


## Issue

- https://github.com/silverstripe/.github/issues/416