### PR TITLE
FIX Check all classes and don't rely on connection_attempted()

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -850,7 +850,7 @@ class DataObjectSchema
         }
 
         // Bail if there's no active database connection yet
-        if (!DB::connection_attempted() || !DB::is_active()) {
+        if (!DB::is_active()) {
             return false;
         }
 
@@ -870,7 +870,7 @@ class DataObjectSchema
             }
 
             // Don't check again if we already know the db is ready for this class.
-            if (!empty($this->tableReadyClasses[$class])) {
+            if (!empty($this->tableReadyClasses[$required])) {
                 continue;
             }
 

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -516,12 +516,13 @@ class DataObjectSchemaTest extends SapphireTest
         $this->assertTrue($schema->tablesAreReadyForClass(Folder::class), 'Folder table should be ready at start');
 
         // Reset cache and drop a column from the subclass. See AdditionalFieldsExtension
+        // Note that the superclass also reports as not ready because File::get() will return images as well.
         $schema->clearTableReadyForClass();
         DB::query(sprintf(
             'ALTER TABLE "%s" DROP COLUMN "SomeField";',
             DataObject::getSchema()->tableForField(Folder::class, 'SomeField')
         ));
-        $this->assertTrue($schema->tablesAreReadyForClass(File::class), 'File table should be ready after drop column');
+        $this->assertFalse($schema->tablesAreReadyForClass(File::class), 'File table should NOT be ready after drop column');
         $this->assertTrue($schema->tablesAreReadyForClass(Image::class), 'Image table should be ready after drop column');
         $this->assertFalse($schema->tablesAreReadyForClass(Folder::class), 'Folder table should NOT be ready after drop column');
 
@@ -542,7 +543,7 @@ class DataObjectSchemaTest extends SapphireTest
         $schema->reset();
         // Add an extension that adds new columns
         Image::add_extension(AdditionalFieldsExtension::class);
-        $this->assertTrue($schema->tablesAreReadyForClass(File::class), 'File table should be ready after add extension');
+        $this->assertFalse($schema->tablesAreReadyForClass(File::class), 'File table should NOT be ready after add extension');
         $this->assertFalse($schema->tablesAreReadyForClass(Image::class), 'Image table should NOT be ready after add extension');
         $this->assertTrue($schema->tablesAreReadyForClass(Folder::class), 'Folder table should be ready after add extension');
 


### PR DESCRIPTION
`DB::is_active()` will lazy-connect to the database if we haven't done so already. That means the `DB::connection_attempted()` check was actually preventing us from connecting to the database even though we were ready to do so.

There's no need to add that check after checking `DB::is_active()` because it'll either be active (and we're good to go) or not (and we should say we're not ready).

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/11806