### PR TITLE
MNT Fix broken unit test

### DIFF
--- a/tests/php/Security/PermissionTest.php
+++ b/tests/php/Security/PermissionTest.php
@@ -11,15 +11,14 @@ use SilverStripe\Dev\SapphireTest;
 
 class PermissionTest extends SapphireTest
 {
-
     protected static $fixture_file = 'PermissionTest.yml';
 
     public function testGetCodesGrouped()
     {
         $codes = Permission::get_codes();
-        $this->assertArrayNotHasKey('SITETREE_VIEW_ALL', $codes);
+        $this->assertArrayNotHasKey('X_SITETREE_VIEW_ALL', $codes);
         $this->assertArrayHasKey('Other', $codes);
-        $this->assertArrayNotHasKey('SITETREE_VIEW_ALL', $codes['Other']);
+        $this->assertArrayHasKey('X_SITETREE_VIEW_ALL', $codes['Other']);
         $this->assertArrayHasKey('Administrator', $codes);
         $this->assertArrayHasKey('ADMIN', $codes['Administrator']);
         $this->assertArrayHasKey('TEST_CMS_EDITOR', $codes['Other']);
@@ -28,7 +27,7 @@ class PermissionTest extends SapphireTest
     public function testGetCodesUngrouped()
     {
         $codes = Permission::get_codes(false);
-        $this->assertArrayHasKey('SITETREE_VIEW_ALL', $codes);
+        $this->assertArrayHasKey('X_SITETREE_VIEW_ALL', $codes);
         $this->assertArrayHasKey('TEST_CMS_EDITOR', $codes);
         $this->assertArrayNotHasKey('Other', $codes);
         $this->assertArrayNotHasKey('Administrator', $codes);
@@ -38,7 +37,7 @@ class PermissionTest extends SapphireTest
     public function testDirectlyAppliedPermissions()
     {
         $member = $this->objFromFixture(Member::class, 'author');
-        $this->assertTrue(Permission::checkMember($member, "SITETREE_VIEW_ALL"));
+        $this->assertTrue(Permission::checkMember($member, "X_SITETREE_VIEW_ALL"));
     }
 
     public function testCMSAccess()
@@ -89,7 +88,7 @@ class PermissionTest extends SapphireTest
         $this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_AssetAdmin"));
         $this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin"));
         $this->assertTrue(Permission::checkMember($member, "EDIT_PERMISSIONS"));
-        $this->assertFalse(Permission::checkMember($member, "SITETREE_VIEW_ALL"));
+        $this->assertFalse(Permission::checkMember($member, "X_SITETREE_VIEW_ALL"));
     }
 
     public function testPermissionsForMember()
@@ -115,14 +114,14 @@ class PermissionTest extends SapphireTest
         $member = $this->objFromFixture(Member::class, 'globalauthor');
 
         // Check that permissions applied to the group are there
-        $this->assertTrue(Permission::checkMember($member, "SITETREE_EDIT_ALL"));
+        $this->assertTrue(Permission::checkMember($member, "X_SITETREE_VIEW_ALL"));
 
         // Check that roles from parent groups are there
         $this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_MyAdmin"));
         $this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_AssetAdmin"));
 
         // Check that permissions from parent groups are there
-        $this->assertTrue(Permission::checkMember($member, "SITETREE_VIEW_ALL"));
+        $this->assertTrue(Permission::checkMember($member, "X_SITETREE_VIEW_ALL"));
 
         // Check that a random permission that shouldn't be there isn't
         $this->assertFalse(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin"));

--- a/tests/php/Security/PermissionTest.yml
+++ b/tests/php/Security/PermissionTest.yml
@@ -65,10 +65,12 @@
 
 'SilverStripe\Security\Permission':
   extra1:
-    Code: SITETREE_VIEW_ALL
+    # Prefixing Code's with "X_" so they do not conflict with the permissions
+    # defined in silverstripe/cms SiteTree::providePermissions()
+    Code: X_SITETREE_VIEW_ALL
     Group: '=>SilverStripe\Security\Group.author'
   globalauthor:
-    Code: SITETREE_EDIT_ALL
+    Code: X_SITETREE_EDIT_ALL
     Group: '=>SilverStripe\Security\Group.globalauthor'
   leftandmain:
     Code: CMS_ACCESS_LeftAndMain


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/442

Fixes https://github.com/silverstripe/recipe-core/actions/runs/16869672310/job/47781947436?pr=112#step:12:227

` 1) SilverStripe\Security\Tests\PermissionTest::testGetCodesGrouped Failed asserting that an array does not have the key 'SITETREE_VIEW_ALL'.`

Issue was that silverstripe/cms was required for this test to pass