### PR TITLE
ENH Reduce count queries for scaffolding `SearchableDropdownField`

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2633,7 +2633,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
         $labelField = $this->hasField('Title') ? 'Title' : 'Name';
         $list = DataList::create(static::class);
         $threshold = DBForeignKey::config()->get('dropdown_field_threshold');
-        $overThreshold = $threshold === 0 || $list->count() > $threshold;
+        $overThreshold = $threshold === 0 || $list->setUseCache(true)->count() > $threshold;
         $field = SearchableDropdownField::create($fieldName, $fieldTitle, $list, $ownerRecord->{$relationName . 'ID'}, $labelField)
             ->setIsLazyLoaded($overThreshold);
         if ($threshold > 0) {

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1491,8 +1491,11 @@ class Member extends DataObject
         $field = SearchableMultiDropdownField::create($relationName, $fieldTitle, $list);
         // Use the same lazyload threshold has_one relations use
         $threshold = DBForeignKey::config()->get('dropdown_field_threshold');
-        $overThreshold = $list->count() > $threshold;
-        $field->setIsLazyLoaded($overThreshold)->setLazyLoadLimit($threshold);
+        $overThreshold = $threshold === 0 || $list->setUseCache(true)->count() > $threshold;
+        $field->setIsLazyLoaded($overThreshold);
+        if ($threshold > 0) {
+            $field->setLazyLoadLimit($threshold);
+        }
         return $field;
     }
 


### PR DESCRIPTION
By caching the count query we can avoid sending repeated count queries for scaffolding multiple `SearchableDropdownField` for the same class.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11645