### PR TITLE
ENH Load Parser over Injector to allow extending

### DIFF
--- a/src/i18n/TextCollection/Parser.php
+++ b/src/i18n/TextCollection/Parser.php
@@ -4,12 +4,15 @@ namespace SilverStripe\i18n\TextCollection;
 
 use SilverStripe\i18n\i18n;
 use SilverStripe\TemplateEngine\SSTemplateParser;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * Parser that scans through a template and extracts the parameters to the _t and <%t calls
  */
 class Parser extends SSTemplateParser
 {
+    use Injectable;
+
     /**
      * List of all entities
      *
@@ -110,7 +113,7 @@ class Parser extends SSTemplateParser
     public static function getTranslatables($template, $warnIfEmpty = true)
     {
         // Run the parser and throw away the result
-        $parser = new Parser($template, $warnIfEmpty);
+        $parser = Parser::create($template, $warnIfEmpty);
         if (substr($template ?? '', 0, 3) == pack("CCC", 0xef, 0xbb, 0xbf)) {
             $parser->pos = 3;
         }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

Use the Injector pattern instead of using new keyword to create object of the Parser class to allow extending.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11819

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
