### PR TITLE
ENH Optimize DataQuery::count() when there's only one table to select from

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -475,9 +475,16 @@ class DataQuery
     public function count()
     {
         $quotedColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
-        return $this->withCorrectDatabase(
-            fn() => $this->getFinalisedQuery()->count("DISTINCT {$quotedColumn}")
-        );
+        return $this->withCorrectDatabase(function () use ($quotedColumn) {
+            $finalisedQuery = $this->getFinalisedQuery();
+            // COUNT(DISTINCT ...) can be slower compared to COUNT(...) because it requires sorting and removing duplicates to find the unique values
+            // When using only one table and counting by ID (and since there are no NULL IDs), we can ignore DISTINCT
+            if (count($finalisedQuery->getFrom()) === 1) {
+                return $finalisedQuery->count($quotedColumn);
+            }
+            // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
+            return $finalisedQuery->count("DISTINCT {$quotedColumn}");
+        });
     }
 
     /**

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -32,6 +32,8 @@ class DataQueryTest extends SapphireTest
         DataQueryTest\ObjectG::class,
         DataQueryTest\ObjectH::class,
         DataQueryTest\ObjectI::class,
+        DataQueryTest\ObjectJ::class,
+        DataQueryTest\ObjectK::class,
         DataQueryTest\ObjectHasMultiRelationalHasOne::class,
         DataQueryTest\ObjectHasMultiRelationalHasMany::class,
         SQLSelectTest\CteRecursiveObject::class,
@@ -466,7 +468,7 @@ class DataQueryTest extends SapphireTest
         $query->sort('"SortOrder"');
         $query->where(
             [
-            '"DataQueryTest_C"."Title" = ?' => ['First']
+                '"DataQueryTest_C"."Title" = ?' => ['First']
             ]
         );
         $result = $query->getFinalisedQuery(['Title']);
@@ -876,5 +878,20 @@ class DataQueryTest extends SapphireTest
         $dataQuery->innerJoin('test_implicit_joins', '"DataQueryTest_G"."ID" = "test_implicit_joins"."ID"');
         // This will throw an exception if it fails - it passes if there's no exception.
         $dataQuery->execute();
+    }
+
+    public function testDistinctCount()
+    {
+        // This should return 1, not 2. We have two records in the "TestKs" relation called 'sam' but only one 'Distinct' ObjectJ parent record
+        $count = DataQueryTest\ObjectJ::get()->filter("TestKs.Name", 'sam')->count();
+        $this->assertEquals(1, $count);
+
+        // We have two 'sam' objects
+        $count = DataQueryTest\ObjectK::get()->filter('Name', 'sam')->count();
+        $this->assertEquals(2, $count);
+
+        $distinct = $this->objFromFixture(DataQueryTest\ObjectJ::class, 'distinct1');
+        $count = $distinct->TestKs()->count();
+        $this->assertEquals(2, $count);
     }
 }

--- a/tests/php/ORM/DataQueryTest.yml
+++ b/tests/php/ORM/DataQueryTest.yml
@@ -90,3 +90,20 @@ SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject:
   child-of-child2:
     Title: 'child of child2'
     Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.child2
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectJ:
+  distinct1:
+    Title: 'Distinct'
+  distinct2:
+    Title: 'OtherDistinct'
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectK:
+  sam1:
+    Name: 'sam'
+    TestJ: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectJ.distinct1
+  sam2:
+    Name: 'sam'
+    TestJ: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectJ.distinct1
+  john1:
+    Name: 'john'
+    TestJ: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectJ.distinct2

--- a/tests/php/ORM/DataQueryTest/ObjectJ.php
+++ b/tests/php/ORM/DataQueryTest/ObjectJ.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectJ extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_J';
+
+    private static $db = [
+        'Title' => 'Varchar'
+    ];
+
+    private static $has_one = [
+        'TestK' => ObjectK::class,
+    ];
+
+    private static $has_many = [
+        'TestKs' => ObjectK::class,
+    ];
+
+    private static $many_many = [
+        'ManyTestKs' => ObjectK::class,
+    ];
+}

--- a/tests/php/ORM/DataQueryTest/ObjectK.php
+++ b/tests/php/ORM/DataQueryTest/ObjectK.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectK extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_K';
+
+    private static $db = [
+        'Name' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'TestJ' => ObjectJ::class,
+    ];
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/447

Kitchen sink ci https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/16952703969

This is a CMS 6.0 version of https://github.com/silverstripe/silverstripe-framework/pull/11642/files#diff-5dea8013fef2ec0e7543bd1d2292cba52963cc83c2673c0ef2df4d0173330325R475 - doing this in a PR rather than directly in a merge-up