### PR TITLE
ENH Skip calling __call for ModelData when unnecessary

### DIFF
--- a/src/View/ViewLayerData.php
+++ b/src/View/ViewLayerData.php
@@ -182,7 +182,7 @@ class ViewLayerData implements IteratorAggregate, Stringable
 
     private function getValueFromData(object $data, string $name, array $arguments): mixed
     {
-        // Values from ModelData can be cached
+        // Values from ModelData can be fetched in a more specific way.
         if ($data instanceof ModelData) {
             $cached = $data->objCacheGet($name, $arguments);
             if ($cached !== null) {
@@ -234,9 +234,16 @@ class ViewLayerData implements IteratorAggregate, Stringable
 
     private function callDataMethod(object $data, string $name, array $arguments, bool &$valueWasFetched = false): mixed
     {
+        $isModelData = $data instanceof ModelData;
         $hasDynamicMethods = method_exists($data, '__call');
         $hasMethod = ClassInfo::hasMethod($data, $name);
-        if ($hasMethod || $hasDynamicMethods) {
+        // ModelData has dynamic methods, though they should only be called if hasMethod returns true.
+        // We don't have a reliable way of checking for the existence of dynamic methods on other classes.
+        $doCallMethod = match ($isModelData) {
+            true => $hasMethod,
+            false => $hasMethod || $hasDynamicMethods,
+        };
+        if ($doCallMethod) {
             try {
                 $value = $data->$name(...$arguments);
                 $valueWasFetched = true;


### PR DESCRIPTION
These enhancements were made using the following test case, which has 100 `DropdownField` instances with 100 options each:

```php
<?php

use SilverStripe\Control\Controller;
use SilverStripe\Control\HTTPRequest;
use SilverStripe\Control\Session;
use SilverStripe\Forms\DropdownField;
use SilverStripe\Forms\FieldList;
use SilverStripe\Forms\Form;

$data = [];
foreach (range(0, 100) as $i) {
    $data[$i] = "Demo $i";
}
$fields = new FieldList();
foreach (range(1, 100) as $i) {
    $fields->push(new DropdownField("Drop{$i}", null, $data));
}

// Necessary for form to render
Controller::config()->set('url_segment', '123');
$controller = new Controller();
$controller->setRequest((new HTTPRequest('GET', ''))->setSession(new Session([])));

$form = new Form(
    $controller,
    fields: $fields
);
$form->disableSecurityToken();

$start = hrtime(true);
$form->forTemplate();
$end = hrtime(true);
$timeInMs = ($end - $start) / 1e+6;
var_dump("{$timeInMs}ms");
```

|Scenario|Time to render|
|---|---|
|Without these changes|~1000ms|
|~~`CastingService` improvement only~~|~~`~900ms`~~|
|`ViewLayerData` improvement only|~800ms|

Those are pretty rough estimates - each time I run it the margin of error is pretty large but it does consistently save _some_ time.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/10174