### PR TITLE
ENH Only use distinct when necessary in DataQuery

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -204,7 +204,7 @@ class DataQuery implements Resettable
 
         // Build our initial query
         $this->query = new SQLSelect([]);
-        $this->query->setDistinct(true);
+        // $this->query->setDistinct(true);
 
         if ($sort = singleton($this->dataClass)->config()->get('default_sort')) {
             $this->sort($sort);
@@ -1040,6 +1040,7 @@ class DataQuery implements Resettable
                 if ($linearOnly) {
                     throw new InvalidArgumentException("$rel is not a linear relation on model $modelClass");
                 }
+                $this->distinct(true);
                 // Join via has_many
                 $this->joinHasManyRelation($modelClass, $rel, $component, $parentPrefix, $tablePrefix, 'has_many');
                 $modelClass = $component;
@@ -1104,6 +1105,7 @@ class DataQuery implements Resettable
             throw new InvalidArgumentException("Could not find a has_many relationship {$localField} on {$localClass}");
         }
         $schema = DataObject::getSchema();
+        $this->distinct(true);
 
         // Skip if already joined
         // Note: don't just check base class, since we need to join on the table with the actual relation key
@@ -1243,6 +1245,7 @@ class DataQuery implements Resettable
         $componentPrefix = null
     ) {
         $schema = DataObject::getSchema();
+        $this->distinct(true);
 
         if (class_exists($relationClassOrTable ?? '')) {
             // class is provided

--- a/src/ORM/ManyManyList.php
+++ b/src/ORM/ManyManyList.php
@@ -65,6 +65,7 @@ class ManyManyList extends RelationList
     public function __construct($dataClass, $joinTable, $localKey, $foreignKey, $extraFields = [])
     {
         parent::__construct($dataClass);
+        $this->dataQuery->distinct(true);
 
         $this->joinTable = $joinTable;
         $this->localKey = $localKey;

--- a/src/ORM/ManyManyThroughList.php
+++ b/src/ORM/ManyManyThroughList.php
@@ -44,6 +44,7 @@ class ManyManyThroughList extends RelationList
         $parentClass = null
     ) {
         parent::__construct($dataClass);
+        $this->dataQuery->distinct(true);
 
         // Inject manipulator
         $this->manipulator = ManyManyThroughQueryManipulator::create(

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -210,7 +210,7 @@ class DataListTest extends SapphireTest
         $queryCounter->startCounting();
         $this->assertEquals(2, $newList->Count(), 'List should only contain two objects after subtraction');
         $queryCounter->stopCounting();
-        // First time through isn't cached
+        // Uses the cached query instead of re-counting
         $this->assertSame(0, $queryCounter->getCount());
     }
 
@@ -617,7 +617,7 @@ class DataListTest extends SapphireTest
     public function testDistinct()
     {
         $list = TeamComment::get();
-        $this->assertStringContainsString('SELECT DISTINCT', $list->dataQuery()->sql($params), 'Query is set as distinct by default');
+        $this->assertStringNotContainsString('SELECT DISTINCT', $list->dataQuery()->sql($params), 'Query is not set as distinct by default');
 
         $list = $list->distinct(false);
         $this->assertStringNotContainsString('SELECT DISTINCT', $list->dataQuery()->sql($params), 'Query does not contain distinct');
@@ -664,7 +664,7 @@ class DataListTest extends SapphireTest
     {
         $db = DB::get_conn();
         $list = TeamComment::get();
-        $expected = 'SELECT DISTINCT "DataObjectTest_TeamComment"."ClassName", '
+        $expected = 'SELECT "DataObjectTest_TeamComment"."ClassName", '
             . '"DataObjectTest_TeamComment"."LastEdited", "DataObjectTest_TeamComment"."Created", '
             . '"DataObjectTest_TeamComment"."Name", "DataObjectTest_TeamComment"."Comment", '
             . '"DataObjectTest_TeamComment"."TeamID", "DataObjectTest_TeamComment"."ID", '
@@ -706,7 +706,7 @@ class DataListTest extends SapphireTest
             'Team'
         );
 
-        $expected = 'SELECT DISTINCT "DataObjectTest_TeamComment"."ClassName", '
+        $expected = 'SELECT "DataObjectTest_TeamComment"."ClassName", '
             . '"DataObjectTest_TeamComment"."LastEdited", "DataObjectTest_TeamComment"."Created", '
             . '"DataObjectTest_TeamComment"."Name", "DataObjectTest_TeamComment"."Comment", '
             . '"DataObjectTest_TeamComment"."TeamID", "DataObjectTest_TeamComment"."ID", '
@@ -737,7 +737,7 @@ class DataListTest extends SapphireTest
             ['Team%']
         );
 
-        $expected = 'SELECT DISTINCT "DataObjectTest_TeamComment"."ClassName", '
+        $expected = 'SELECT "DataObjectTest_TeamComment"."ClassName", '
             . '"DataObjectTest_TeamComment"."LastEdited", "DataObjectTest_TeamComment"."Created", '
             . '"DataObjectTest_TeamComment"."Name", "DataObjectTest_TeamComment"."Comment", '
             . '"DataObjectTest_TeamComment"."TeamID", "DataObjectTest_TeamComment"."ID", '

--- a/tests/php/ORM/DataObjectLazyLoadingTest.php
+++ b/tests/php/ORM/DataObjectLazyLoadingTest.php
@@ -28,7 +28,7 @@ class DataObjectLazyLoadingTest extends SapphireTest
         $db = DB::get_conn();
         $playerList = new DataList(SubTeam::class);
         $playerList = $playerList->setQueriedColumns(['ID']);
-        $expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_Team"."ID", CASE WHEN ' . '"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END AS "RecordClassName", "DataObjectTest_Team"."Title" ' . 'FROM "DataObjectTest_Team" ' . 'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" ' . 'WHERE ("DataObjectTest_Team"."ClassName" IN (?))' . ' ORDER BY "DataObjectTest_Team"."Title" ASC';
+        $expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_Team"."ID", CASE WHEN ' . '"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END AS "RecordClassName", "DataObjectTest_Team"."Title" ' . 'FROM "DataObjectTest_Team" ' . 'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" ' . 'WHERE ("DataObjectTest_Team"."ClassName" IN (?))' . ' ORDER BY "DataObjectTest_Team"."Title" ASC';
         $this->assertSQLEquals($expected, $playerList->sql($parameters));
     }
 
@@ -37,7 +37,7 @@ class DataObjectLazyLoadingTest extends SapphireTest
         $db = DB::get_conn();
         $playerList = new DataList(SubTeam::class);
         $playerList = $playerList->setQueriedColumns(['Title', 'SubclassDatabaseField']);
-        $expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_Team"."Title", ' . '"DataObjectTest_SubTeam"."SubclassDatabaseField", "DataObjectTest_Team"."ID", CASE WHEN ' . '"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END AS "RecordClassName" FROM "DataObjectTest_Team" ' . 'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" WHERE ' . '("DataObjectTest_Team"."ClassName" IN (?)) ' . 'ORDER BY "DataObjectTest_Team"."Title" ASC';
+        $expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_Team"."Title", ' . '"DataObjectTest_SubTeam"."SubclassDatabaseField", "DataObjectTest_Team"."ID", CASE WHEN ' . '"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END AS "RecordClassName" FROM "DataObjectTest_Team" ' . 'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" WHERE ' . '("DataObjectTest_Team"."ClassName" IN (?)) ' . 'ORDER BY "DataObjectTest_Team"."Title" ASC';
         $this->assertSQLEquals($expected, $playerList->sql($parameters));
     }
 
@@ -46,7 +46,7 @@ class DataObjectLazyLoadingTest extends SapphireTest
         $db = DB::get_conn();
         $playerList = new DataList(SubTeam::class);
         $playerList = $playerList->setQueriedColumns(['Title']);
-        $expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_Team"."Title", "DataObjectTest_Team"."ID", ' . 'CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END AS "RecordClassName" FROM "DataObjectTest_Team" ' . 'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" WHERE ' . '("DataObjectTest_Team"."ClassName" IN (?)) ' . 'ORDER BY "DataObjectTest_Team"."Title" ASC';
+        $expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_Team"."Title", "DataObjectTest_Team"."ID", ' . 'CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END AS "RecordClassName" FROM "DataObjectTest_Team" ' . 'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" WHERE ' . '("DataObjectTest_Team"."ClassName" IN (?)) ' . 'ORDER BY "DataObjectTest_Team"."Title" ASC';
         $this->assertSQLEquals($expected, $playerList->sql($parameters));
     }
 
@@ -55,7 +55,7 @@ class DataObjectLazyLoadingTest extends SapphireTest
         $db = DB::get_conn();
         $playerList = new DataList(SubTeam::class);
         $playerList = $playerList->setQueriedColumns(['SubclassDatabaseField']);
-        $expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_SubTeam"."SubclassDatabaseField", ' . '"DataObjectTest_Team"."ID", CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN ' . '"DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END ' . 'AS "RecordClassName", "DataObjectTest_Team"."Title" ' . 'FROM "DataObjectTest_Team" LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = ' . '"DataObjectTest_Team"."ID" WHERE ("DataObjectTest_Team"."ClassName" IN (?)) ' . 'ORDER BY "DataObjectTest_Team"."Title" ASC';
+        $expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."LastEdited", ' . '"DataObjectTest_Team"."Created", "DataObjectTest_SubTeam"."SubclassDatabaseField", ' . '"DataObjectTest_Team"."ID", CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN ' . '"DataObjectTest_Team"."ClassName" ELSE ' . $db->quoteString(Team::class) . ' END ' . 'AS "RecordClassName", "DataObjectTest_Team"."Title" ' . 'FROM "DataObjectTest_Team" LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = ' . '"DataObjectTest_Team"."ID" WHERE ("DataObjectTest_Team"."ClassName" IN (?)) ' . 'ORDER BY "DataObjectTest_Team"."Title" ASC';
         $this->assertSQLEquals($expected, $playerList->sql($parameters));
     }
 
@@ -68,7 +68,7 @@ class DataObjectLazyLoadingTest extends SapphireTest
             0,
             preg_match(
                 $this->normaliseSQL(
-                    '/SELECT DISTINCT "DataObjectTest_Team"."ID" .* LEFT JOIN .* FROM "DataObjectTest_Team"/'
+                    '/SELECT "DataObjectTest_Team"."ID" .* LEFT JOIN .* FROM "DataObjectTest_Team"/'
                 ) ?? '',
                 $this->normaliseSQL($playerList->sql($parameters)) ?? ''
             )
@@ -83,7 +83,7 @@ class DataObjectLazyLoadingTest extends SapphireTest
         $this->assertEquals(
             1,
             preg_match(
-                $this->normaliseSQL('/SELECT DISTINCT .* LEFT JOIN .* /') ?? '',
+                $this->normaliseSQL('/SELECT .* LEFT JOIN .* /') ?? '',
                 $this->normaliseSQL($playerList->sql($parameters)) ?? ''
             )
         );

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -340,7 +340,7 @@ class DataQueryTest extends SapphireTest
     public function testDistinct()
     {
         $query = new DataQuery(DataQueryTest\ObjectE::class);
-        $this->assertStringContainsString('SELECT DISTINCT', $query->sql($params), 'Query is set as distinct by default');
+        $this->assertStringNotContainsString('SELECT DISTINCT', $query->sql($params), 'Query is not set as distinct by default');
 
         $query = $query->distinct(false);
         $this->assertStringNotContainsString('SELECT DISTINCT', $query->sql($params), 'Query does not contain distinct');


### PR DESCRIPTION
Selecting `DISTINCT` fields in MySQL often results in using temporary tables, which slows execution. We should only use it when it's actually necessary.

This PR is for exploring how we might do that in a way that doesn't break things.

## TODO

- Validate if this actually speeds anything up (ORM unit tests and behat tests are taking the same amount of time so that's not a good sign)
- If not sped up, check if I did something wrong

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/4923