### PR TITLE
ENH use query caching for permissions

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -109,8 +109,8 @@ class DataList extends ModelData implements SS_List, Resettable
         if ($class) {
             // Reset for all superclasses as well, since superclass queries
             // include records from subclasses
-            $classHierarchy = ClassInfo::ancestry($class);
-            foreach ($classHierarchy as $currentClass) {
+            $classesToReset = DataQuery::getClassesForQueryCacheReset(ClassInfo::ancestry($class));
+            foreach ($classesToReset as $currentClass) {
                 unset(DataList::$cachedQueries[$currentClass]);
             }
         } else {

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -370,6 +370,15 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
     private static ?DataObjectSchema $schema = null;
 
     /**
+     * A list of DataObject subclasses whose query caches should be reset whenever resetting
+     * the query cache for this class.
+     *
+     * Do not include other classes from the current hierarchy in this list.
+     * i.e. Page should not include SiteTree or vice versa.
+     */
+    private static array $query_cache_dependent_classes = [];
+
+    /**
      * Get schema object
      *
      * @return DataObjectSchema

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\Connect\Query;
 use SilverStripe\ORM\Queries\SQLConditionGroup;
 use SilverStripe\ORM\Queries\SQLSelect;
 use InvalidArgumentException;
+use SilverStripe\Core\ArrayLib;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Resettable;
 use SilverStripe\Dev\Deprecation;
@@ -92,12 +93,33 @@ class DataQuery implements Resettable
             return;
         }
 
-        // Reset for all superclasses as well, since superclass queries
-        // include records from subclasses
-        $classHierarchy = ClassInfo::ancestry($class);
-        foreach ($classHierarchy as $currentClass) {
+        // Reset for all superclasses and dependent classes as well, since superclass queries include
+        // records from subclasses
+        $classesToReset = static::getClassesForQueryCacheReset(ClassInfo::ancestry($class));
+        foreach ($classesToReset as $currentClass) {
             SQLSelect::reset($currentClass);
         }
+    }
+
+    /**
+     * Get the full set of class names that need to be reset, based on the query_cache_dependent_classes
+     * configuration property of the passed in classes.
+     */
+    public static function getClassesForQueryCacheReset(array $classes): array
+    {
+        /** @var class-string<DataObject> $class */
+        foreach (ArrayLib::iterateVolatile($classes) as $class) {
+            $dependents = $class::config()->get('query_cache_dependent_classes') ?? [];
+            $remainingDependents = array_diff($dependents, $classes);
+            foreach ($remainingDependents as $dependentClass) {
+                foreach (ClassInfo::ancestry($dependentClass) as $key => $value) {
+                    if (!isset($classes[$key])) {
+                        $classes[$key] = $value;
+                    }
+                }
+            }
+        }
+        return $classes;
     }
 
     /**

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -59,7 +59,6 @@ use SilverStripe\Core\Validation\ValidationResult;
  */
 class Group extends DataObject
 {
-
     private static $db = [
         "Title" => "Varchar(255)",
         "Description" => "Text",
@@ -98,6 +97,13 @@ class Group extends DataObject
     ];
 
     private static bool $require_sudo_mode = true;
+
+    private static array $query_cache_dependent_classes = [
+        Permission::class,
+        PermissionRole::class,
+        PermissionRoleCode::class,
+        Member::class,
+    ];
 
     public function getAllChildren()
     {

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -275,6 +275,13 @@ class Member extends DataObject
      */
     private static $auto_login_token_lifetime = 172800;
 
+    private static array $query_cache_dependent_classes = [
+        Permission::class,
+        PermissionRole::class,
+        PermissionRoleCode::class,
+        Group::class,
+    ];
+
     /**
      * Used to track whether {@link Member::changePassword} has made changed that need to be written. Used to prevent
      * the write from calling changePassword again.
@@ -848,8 +855,6 @@ class Member extends DataObject
     protected function onAfterWrite()
     {
         parent::onAfterWrite();
-
-        Permission::reset();
 
         if ($this->isChanged('Password') && static::config()->get('password_logging_enabled')) {
             MemberPassword::log($this);
@@ -1846,5 +1851,11 @@ class Member extends DataObject
             throw new RuntimeException('Unable to generate a random password');
         }
         return $password;
+    }
+
+    public function flushCache(bool $persistent = true): static
+    {
+        Permission::reset();
+        return parent::flushCache($persistent);
     }
 }

--- a/src/Security/Member_GroupSet.php
+++ b/src/Security/Member_GroupSet.php
@@ -87,6 +87,9 @@ class Member_GroupSet extends ManyManyList
         if ($this->canAddGroups([$itemID])) {
             parent::add($item, $extraFields ?? []);
         }
+
+        // We must invalidate cache to ensure cached relation lists get up-to-date data
+        static::reset($this->dataClass());
     }
 
     public function removeAll()
@@ -117,6 +120,11 @@ class Member_GroupSet extends ManyManyList
             "\"{$this->joinTable}\".\"{$this->localKey}\" IN ($subSelect)" => $parameters
         ]);
         $delete->execute();
+
+        // Even though the underlying records aren't deleted, we still need to
+        // reset the query cache for this class, so that any cached relation lists
+        // will have the correct data.
+        static::reset($this->dataClass());
     }
 
     /**

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -24,7 +24,6 @@ use SilverStripe\View\TemplateGlobalProvider;
  */
 class Permission extends DataObject implements TemplateGlobalProvider, Resettable, i18nEntityProvider
 {
-
     // the (1) after Type specifies the DB default value which is needed for
     // upgrades from older SilverStripe versions
     private static $db = [
@@ -107,6 +106,13 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
     ];
 
     private static bool $require_sudo_mode = true;
+
+    private static array $query_cache_dependent_classes = [
+        PermissionRole::class,
+        PermissionRoleCode::class,
+        Group::class,
+        Member::class,
+    ];
 
     /**
      * Check that the current member has the given permission.
@@ -209,9 +215,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
         // Code filters
         $codeParams = is_array($code) ? $code : [$code];
-        $codeClause = DB::placeholders($codeParams);
         $adminParams = $adminImpliesAll ? ['ADMIN'] : [];
-        $adminClause = $adminImpliesAll ?  ", ?" : '';
 
         // The following code should only be used if you're not using the "any" arg.  This is kind
         // of obsolete functionality and could possibly be deprecated.
@@ -219,7 +223,6 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
         if (empty($groupParams)) {
             return false;
         }
-        $groupClause = DB::placeholders($groupParams);
 
         // Arg component
         $argClause = "";
@@ -241,39 +244,30 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
         }
 
         // Raw SQL for efficiency
-        $permission = DB::withPrimary(fn() => DB::prepared_query(
-            "SELECT \"ID\"
-            FROM \"Permission\"
-            WHERE (
-                \"Code\" IN ($codeClause $adminClause)
-                AND \"Type\" = ?
-                AND \"GroupID\" IN ($groupClause)
-                $argClause
-            )",
-            array_merge(
-                $codeParams,
-                $adminParams,
-                [Permission::GRANT_PERMISSION],
-                $groupParams,
-                $argParams
-            )
-        )->value());
+        $permissionIDs = Permission::get()
+            ->setUseCache(true)
+            ->filter([
+                'Code' => [...$adminParams, ...$codeParams],
+                'Type' => Permission::GRANT_PERMISSION,
+                'GroupID' => $groupParams
+            ])
+            ->where([$argClause => $argParams])
+            ->limit(1)
+            ->column('ID');
 
-        if ($permission) {
-            return $permission;
+        if ($permissionIDs) {
+            return array_pop($permissionIDs);
         }
 
         // Strict checking disabled?
-        if (!static::config()->strict_checking || !$strict) {
-            $hasPermission = DB::withPrimary(fn() => DB::prepared_query(
-                "SELECT COUNT(*)
-                FROM \"Permission\"
-                WHERE (
-                    \"Code\" IN ($codeClause) AND
-                    \"Type\" = ?
-                )",
-                array_merge($codeParams, [Permission::GRANT_PERMISSION])
-            )->value());
+        if (!static::config()->get('strict_checking') || !$strict) {
+            $hasPermission = Permission::get()
+                ->setUseCache(true)
+                ->filter([
+                    'Code' => $codeParams,
+                    'Type' => Permission::GRANT_PERMISSION,
+                ])
+                ->exists();
 
             if (!$hasPermission) {
                 return false;
@@ -297,6 +291,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
             // Get the allowed permissions for this user based on the permissions assigned
             // directly to its groups, and the permissions assigned to roles on its groups.
             $allowed = Permission::get()
+                ->setUseCache(true)
                 ->filter([
                     'Type' => Permission::GRANT_PERMISSION,
                     'GroupID' => $groupIDs,
@@ -305,13 +300,14 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
                     $schema = DataObject::getSchema();
                     // These permissions are explicitly NOT allowed and
                     // need to be excluded from the PermissionRoleCode set
-                    $denied = Permission::get()->filter([
+                    $denied = Permission::get()->setUseCache(true)->filter([
                         'Type' => Permission::DENY_PERMISSION,
                         'GroupID' => $groupIDs,
                     ]);
 
                     // Get permission codes from roles these groups are assigned to, exluding the denied list above.
                     $permissionRoleCodes = PermissionRoleCode::get()
+                        ->setUseCache(true)
                         ->filter(['GroupID' => $groupIDs])
                         ->excludeByList($denied, 'Code', 'Code')
                         // Apply necessary joins
@@ -358,7 +354,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
         if ($member) {
             // Build a list of the IDs of the groups.
-            $groupIDs = $member->Groups()->column();
+            $groupIDs = $member->Groups()->setUseCache(true)->column();
 
             // Session caching
             if (!$memberID) {
@@ -482,6 +478,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
         $groupClause = DB::placeholders($groupIDs);
         $members = Member::get()
+            ->setUseCache(true)
             ->where(["\"Group\".\"ID\" IN ($groupClause)" => $groupIDs])
             ->leftJoin("Group_Members", '"Member"."ID" = "Group_Members"."MemberID"')
             ->leftJoin("Group", '"Group_Members"."GroupID" = "Group"."ID"');
@@ -501,6 +498,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
         // Via Roles are groups that have the permission via a role
         return Group::get()
+            ->setUseCache(true)
             ->where([
                 "\"PermissionRoleCode\".\"Code\" IN ($codeClause) OR \"Permission\".\"Code\" IN ($codeClause)"
                 => array_merge($codeParams, $codeParams)
@@ -641,19 +639,17 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
         }
     }
 
-    protected function onBeforeWrite()
-    {
-        parent::onBeforeWrite();
-
-        // Just in case we've altered someone's permissions
-        Permission::reset();
-    }
-
     public static function get_template_global_variables()
     {
         return [
             'HasPerm' => 'check'
         ];
+    }
+
+    public function flushCache(bool $persistent = true): static
+    {
+        Permission::reset();
+        return parent::flushCache($persistent);
     }
 
     public function provideI18nEntities()

--- a/src/Security/PermissionRole.php
+++ b/src/Security/PermissionRole.php
@@ -50,6 +50,13 @@ class PermissionRole extends DataObject
 
     private static bool $require_sudo_mode = true;
 
+    private static array $query_cache_dependent_classes = [
+        Permission::class,
+        PermissionRoleCode::class,
+        Group::class,
+        Member::class,
+    ];
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();

--- a/src/Security/PermissionRoleCode.php
+++ b/src/Security/PermissionRoleCode.php
@@ -36,6 +36,13 @@ class PermissionRoleCode extends DataObject
         ],
     ];
 
+    private static array $query_cache_dependent_classes = [
+        Permission::class,
+        PermissionRole::class,
+        Group::class,
+        Member::class,
+    ];
+
     public function validate(): ValidationResult
     {
         $result = parent::validate();


### PR DESCRIPTION
> [!IMPORTANT]
> Intentionally two commits. DO NOT SQUASH

Permissions are checked all over the place - we should be caching them if it's safe to do so.

## Performance test

Using the following setup with 7 members that have the `CMS_ACCESS_CMSMain` permission:

```php
$start = hrtime(true);
$members = Permission::get_members_by_permission('CMS_ACCESS_CMSMain');
$output->writeln('Found ' . count($members) . ' members');

foreach (range(1, 100) as $i) {
    foreach ($members as $member) {
        Permission::check('ADMIN', member: $member);
    }
}
$end = hrtime(true);

$timeInMs = ($end - $start) / 1e+6;
```

I got these results, averaged out over 10 attempts with and without this PR.

|with PR|without PR|
|---|---|
|86.75ms|133.73ms|

This will be useful with scenarios like viewing collections of files (`File::canView()` does _at least_ one check per file, but can be multiple depending on inherited permission settings) or pages (`SiteTree::canView()` is similar to `File::canView()`)

## Todo

- Check if it's safe
  - add tests

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/10835