### PR TITLE
ENH Disable sorting on queries where sort order doesn't matter

### DIFF
--- a/src/Forms/MultiSelectField.php
+++ b/src/Forms/MultiSelectField.php
@@ -127,7 +127,7 @@ abstract class MultiSelectField extends SelectField
         // Detect DB relation or field
         if ($relation instanceof Relation) {
             // Load ids from relation
-            $value = array_values($relation->getIDList() ?? []);
+            $value = $relation->sort(null)->column('ID');
             parent::setValue($value);
         } elseif ($record->hasField($fieldName)) {
             // Load dataValue from field... a CSV for DBMultiEnum

--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -771,7 +771,7 @@ class TreeDropdownField extends FormField implements HasOneRelationFieldInterfac
             }
             $this->searchIds[$row->ID] = true;
         }
-        $this->realSearchIds = $res->column();
+        $this->realSearchIds = $res->sort(null)->column('ID');
 
         $sourceObject = $this->getSourceObject();
 

--- a/src/Model/List/ArrayList.php
+++ b/src/Model/List/ArrayList.php
@@ -455,19 +455,24 @@ class ArrayList extends ModelData implements SS_List
      */
     public function sort(...$args): static
     {
-        if (count($args ?? [])==0) {
+        $numArgs = count($args);
+        // If explicitly not sorting, just return the list back
+        if ($numArgs == 0) {
             return $this;
         }
-        if (count($args ?? [])>2) {
+        if ($numArgs === 1 && $args[0] === null) {
+            return $this;
+        }
+        if ($numArgs > 2) {
             throw new InvalidArgumentException('This method takes zero, one or two arguments');
         }
         $columnsToSort = [];
 
         // One argument and it's a string
-        if (count($args ?? [])==1 && is_string($args[0])) {
+        if ($numArgs === 1 && is_string($args[0])) {
             list($column, $direction) = $this->parseSortColumn($args[0]);
             $columnsToSort[$column] = $direction;
-        } elseif (count($args ?? [])==2) {
+        } elseif ($numArgs === 2) {
             list($column, $direction) = $this->parseSortColumn($args[0], $args[1]);
             $columnsToSort[$column] = $direction;
         } elseif (is_array($args[0])) {

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1913,12 +1913,8 @@ class DataList extends ModelData implements SS_List, Resettable
      */
     public function setByIDList($idList)
     {
-        $has = [];
-
-        // Index current data
-        foreach ($this->column() as $id) {
-            $has[$id] = true;
-        }
+        // Track current data
+        $has = array_fill_keys($this->sort(null)->column('ID'), true);
 
         // Keep track of items to delete
         $itemsToDelete = $has;
@@ -1943,9 +1939,11 @@ class DataList extends ModelData implements SS_List, Resettable
      * Does not respect sort order. Use ->column("ID") to get an ID list with the current sort.
      *
      * @return array<int>
+     * @deprecated 6.2.0 Use `$list->sort(null)->column('ID')` instead.
      */
     public function getIDList()
     {
+        Deprecation::notice('6.2.0', 'Use `$list->sort(null)->column(\'ID\')` instead.');
         $ids = $this->column("ID");
         return $ids ? array_combine($ids, $ids) : [];
     }
@@ -2012,7 +2010,8 @@ class DataList extends ModelData implements SS_List, Resettable
      */
     public function removeByFilter($filter)
     {
-        foreach ($this->where($filter) as $item) {
+        // Disabling sort improves performance
+        foreach ($this->sort(null)->where($filter) as $item) {
             $this->remove($item);
         }
         return $this;
@@ -2035,7 +2034,8 @@ class DataList extends ModelData implements SS_List, Resettable
      */
     public function removeAll()
     {
-        foreach ($this as $item) {
+        // Disabling sort improves performance
+        foreach ($this->sort(null) as $item) {
             $this->remove($item);
         }
         return $this;
@@ -2188,12 +2188,12 @@ class DataList extends ModelData implements SS_List, Resettable
      * Prepopulate any extension caches with the current dataclass and IDs of records
      *
      * Note that because this calls column() and may result in other database queries based on
-     * the IDs that returns, this should be called after all filtering, sorting, etc has already
+     * the IDs that returns, this should be called after all filtering, etc has already
      * been set for this list.
      */
     public function prepopulateCaches(): void
     {
-        $ids = $this->column('ID');
+        $ids = $this->sort(null)->column('ID');
         $this->extend('onPrepopulateCaches', $ids);
     }
 

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -640,7 +640,8 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
             $extraFieldNames = [];
         }
 
-        foreach ($source as $item) {
+        // Disabling sort improves performance
+        foreach ($source->sort(null) as $item) {
             // Merge extra fields
             $extraFields = [];
             foreach ($extraFieldNames as $fieldName => $fieldType) {
@@ -663,7 +664,8 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
         $source = $sourceObject->getComponents($relation);
         $dest = $destinationObject->getComponents($relation);
 
-        foreach ($source as $item) {
+        // Disabling sort improves performance
+        foreach ($source->sort(null) as $item) {
             // Don't write on duplicate; Wait until ParentID is available later.
             // writeRelations() will eventually write these records when converting
             // from UnsavedRelationList
@@ -1208,7 +1210,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                     $leftComponents = $leftObj->getManyManyComponents($relationship);
                     $rightComponents = $rightObj->getManyManyComponents($relationship);
                     if ($rightComponents && $rightComponents->exists()) {
-                        $leftComponents->addMany($rightComponents->column('ID'));
+                        $leftComponents->addMany($rightComponents->sort(null)->column('ID'));
                     }
                     $leftComponents->write();
                 }
@@ -1219,7 +1221,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                     $leftComponents = $leftObj->getComponents($relationship);
                     $rightComponents = $rightObj->getComponents($relationship);
                     if ($rightComponents && $rightComponents->exists()) {
-                        $leftComponents->addMany($rightComponents->column('ID'));
+                        $leftComponents->addMany($rightComponents->sort(null)->column('ID'));
                     }
                     $leftComponents->write();
                 }

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -172,8 +172,12 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
         return singleton($this->dataClass)->dbObject($fieldName);
     }
 
+    /**
+     * @deprecated 6.2.0 Use `$list->column('ID')` instead.
+     */
     public function getIDList(): array
     {
+        Deprecation::notice('6.2.0', 'Use `$list->column(\'ID\')` instead.');
         $ids = $this->column('ID');
         return array_combine($ids, $ids);
     }

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -460,7 +460,8 @@ class Hierarchy extends Extension
         foreach ($parentIDs as $parentID) {
             Hierarchy::$children_for_tree_ids_cache[$baseClass][$parentID] = [];
         }
-        foreach ($children as $child) {
+        // Disabling sort improves performance
+        foreach ($children->sort(null) as $child) {
             $childID = $child->ID;
             $parentID = $child->ParentID;
             Hierarchy::$children_for_tree_ids_cache[$baseClass][$parentID][] = $childID;
@@ -560,7 +561,7 @@ class Hierarchy extends Extension
     {
         if (empty($options['numChildrenMethod']) || $options['numChildrenMethod'] === 'numChildren') {
             $idList = is_array($recordList) ? $recordList :
-                ($recordList instanceof DataList ? $recordList->column('ID') : null);
+                ($recordList instanceof DataList ? $recordList->sort(null)->column('ID') : null);
             Hierarchy::prepopulate_numchildren_cache($this->getHierarchyBaseClass(), $idList);
         }
 

--- a/src/ORM/ManyManyThroughList.php
+++ b/src/ORM/ManyManyThroughList.php
@@ -153,7 +153,7 @@ class ManyManyThroughList extends RelationList
     public function removeAll()
     {
         // Get the IDs of records in the current list
-        $affectedIds = $this->limit(null)->column('ID');
+        $affectedIds = $this->limit(null)->sort(null)->column('ID');
         if (empty($affectedIds)) {
             return;
         }
@@ -164,8 +164,8 @@ class ManyManyThroughList extends RelationList
             $this->manipulator->getLocalKey() => $affectedIds,
         ]);
 
-        /** @var DataObject $record */
-        foreach ($records as $record) {
+        // Disabling sort improves performance
+        foreach ($records->sort(null) as $record) {
             $record->delete();
         }
 
@@ -218,7 +218,8 @@ class ManyManyThroughList extends RelationList
         $foreignKey = $this->manipulator->getForeignIDKey();
         $hasManyList = $this->manipulator->getParentRelationship($this->dataQuery());
         $records = $hasManyList->filter($localKey, $itemID);
-        foreach ($records as $record) {
+        // Disabling sort improves performance
+        foreach ($records->sort(null) as $record) {
             if ($extraFields) {
                 foreach ($extraFields as $field => $value) {
                     $record->$field = $value;

--- a/src/ORM/Relation.php
+++ b/src/ORM/Relation.php
@@ -34,6 +34,7 @@ interface Relation extends SS_List
      * Does not return the IDs for unsaved DataObjects
      *
      * @return array<int>
+     * @deprecated 6.2.0 Use `$list->sort(null)->column('ID')` instead.
      */
     public function getIDList();
 

--- a/src/ORM/UnsavedRelationList.php
+++ b/src/ORM/UnsavedRelationList.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM;
 
 use InvalidArgumentException;
 use ArrayIterator;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\FieldType\DBField;
 use Traversable;
@@ -211,9 +212,11 @@ class UnsavedRelationList extends ArrayList implements Relation
      * Returns an array with both the keys and values set to the IDs of the records in this list.
      * Does not respect sort order. Use ->column("ID") to get an ID list with the current sort.
      * Does not return the IDs for unsaved DataObjects.
+     * @deprecated 6.2.0 Use `$list->column('ID')` instead.
      */
     public function getIDList()
     {
+        Deprecation::notice('6.2.0', 'Use `$list->column(\'ID\')` instead.');
         // Get a list of IDs of our current items - if it's not a number then object then assume it's a DO.
         $ids = array_map(function ($obj) {
             return is_numeric($obj) ? $obj : $obj->ID;

--- a/src/Security/GroupCsvBulkLoader.php
+++ b/src/Security/GroupCsvBulkLoader.php
@@ -33,7 +33,11 @@ class GroupCsvBulkLoader extends CsvBulkLoader
         // are imported to avoid missing "early" references to parents
         // which are imported later on in the CSV file.
         if (isset($record['ParentCode']) && $record['ParentCode']) {
-            $parentGroupIDs = Group::get()->setUseCache(true)->filter('Code', $record['ParentCode'])->column();
+            $parentGroupIDs = Group::get()
+                ->setUseCache(true)
+                ->filter('Code', $record['ParentCode'])
+                ->sort(null)
+                ->column('ID');
             if (!empty($parentGroupIDs)) {
                 $group->ParentID = $parentGroupIDs[0];
                 $group->write();

--- a/src/Security/InheritedPermissionFlusher.php
+++ b/src/Security/InheritedPermissionFlusher.php
@@ -98,7 +98,8 @@ class InheritedPermissionFlusher extends Extension implements Flushable
         }
 
         if ($this->owner instanceof Group) {
-            return $this->owner->Members()->column('ID');
+            // Disabling sort improves performance
+            return $this->owner->Members()->sort(null)->column('ID');
         }
 
         return [$this->owner->ID];

--- a/src/Security/InheritedPermissions.php
+++ b/src/Security/InheritedPermissions.php
@@ -291,7 +291,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
         // Get the groups that the given member belongs to
         $groupIDsSQLList = '0';
         if ($memberID) {
-            $groupIDs = $member->Groups()->column("ID");
+            $groupIDs = $member->Groups()->sort(null)->column('ID');
             $groupIDsSQLList = implode(", ", $groupIDs) ?: '0';
         }
 
@@ -355,7 +355,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
         ?Member $member = null
     ) {
         // Initialise all IDs to false
-        $result = array_fill_keys($stageRecords->column('ID') ?? [], false);
+        $result = array_fill_keys($stageRecords->sort(null)->column('ID'), false);
 
         // Get the uninherited permissions
         $typeField = $this->getPermissionField($type);
@@ -385,14 +385,16 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
                     )->leftJoin(
                         $memberJoinTable,
                         "\"$memberJoinTable\".\"{$baseTable}ID\" = \"{$baseTable}\".\"ID\" AND " . "\"$memberJoinTable\".\"MemberID\" = {$member->ID}"
-                    )->column('ID');
+                    )->sort(null)
+                    ->column('ID');
             } else {
-                $uninheritedPermissions = $stageRecords->column('ID');
+                $uninheritedPermissions = $stageRecords->sort(null)->column('ID');
             }
         } else {
             // Only view pages with ViewType = Anyone if not logged in
             $uninheritedPermissions = $stageRecords
                 ->filter($typeField, InheritedPermissions::ANYONE)
+                ->sort(null)
                 ->column('ID');
         }
 

--- a/src/Security/Member_GroupSet.php
+++ b/src/Security/Member_GroupSet.php
@@ -50,7 +50,8 @@ class Member_GroupSet extends ManyManyList
         $allGroupIDs = [];
         while ($groupIDs) {
             $allGroupIDs = array_merge($allGroupIDs, $groupIDs);
-            $groupIDs = DataObject::get(Group::class)->byIDs($groupIDs)->column("ParentID");
+            // Disabling sort improves performance
+            $groupIDs = DataObject::get(Group::class)->sort(null)->byIDs($groupIDs)->column("ParentID");
             $groupIDs = array_filter($groupIDs ?? []);
         }
 

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -358,7 +358,8 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
         if ($member) {
             // Build a list of the IDs of the groups.
-            $groupIDs = $member->Groups()->column();
+            // Disabling sort improves performance
+            $groupIDs = $member->Groups()->sort(null)->column('ID');
 
             // Session caching
             if (!$memberID) {

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -414,7 +414,7 @@ class FormTest extends FunctionalTest
             ]
         );
         $form->saveInto($object);
-        $playersIds = $object->Players()->getIDList();
+        $playersIds = $object->Players()->sort(null)->column('ID');
 
         $this->assertTrue($form->validate()->isValid());
         $this->assertEquals(

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -2858,6 +2858,17 @@ class DataListTest extends SapphireTest
         ];
     }
 
+    public function testRelationSort(): void
+    {
+        $expected = [
+            ['Title' => 'Test 3'],
+            ['Title' => 'Test 2'],
+            ['Title' => 'Test 1'],
+        ];
+        $list = RelationChildFirst::get()->reverse()->relation('ManyNext');
+        $this->assertListEquals($expected, $list);
+    }
+
     #[DataProvider('provideCreateDataObject')]
     public function testCreateDataObject(string $dataClass, string $realClass, array $row)
     {

--- a/tests/php/ORM/DataObjectDuplicationTest.php
+++ b/tests/php/ORM/DataObjectDuplicationTest.php
@@ -48,8 +48,8 @@ class DataObjectDuplicationTest extends SapphireTest
         );
         $this->assertEmpty(
             array_intersect(
-                $orig->bobcats()->getIDList() ?? [],
-                $duplicate->bobcats()->getIDList()
+                $orig->bobcats()->column('ID') ?? [],
+                $duplicate->bobcats()->column('ID')
             )
         );
         /** @var DataObjectDuplicationTest\Bobcat $twoTwoDuplicate */
@@ -92,8 +92,8 @@ class DataObjectDuplicationTest extends SapphireTest
         );
         // Ids of each record are the same (only mapping content is duplicated)
         $this->assertEquals(
-            $orig->caribou()->getIDList(),
-            $duplicate->caribou()->getIDList()
+            $orig->caribou()->column('ID'),
+            $duplicate->caribou()->column('ID')
         );
 
         // Ensure 'five' belongs_to is duplicated

--- a/tests/php/ORM/DataObjectTest/RelationParent.php
+++ b/tests/php/ORM/DataObjectTest/RelationParent.php
@@ -12,4 +12,6 @@ class RelationParent extends DataObject implements TestOnly
     private static $db = [
         'Title' => 'Varchar(255)',
     ];
+
+    private static string $default_sort = 'Title';
 }

--- a/tests/php/Security/GroupTest.php
+++ b/tests/php/Security/GroupTest.php
@@ -103,14 +103,14 @@ class GroupTest extends FunctionalTest
 
         // Can save user to unsaved group
         $group->Members()->add($member);
-        $this->assertEquals([$member->ID], array_values($group->Members()->getIDList() ?? []));
+        $this->assertEquals([$member->ID], $group->Members()->sort(null)->column('ID'));
 
         // Persists after writing to DB
         $group->write();
 
         /** @var Group $group */
         $group = Group::get()->byID($group->ID);
-        $this->assertEquals([$member->ID], array_values($group->Members()->getIDList() ?? []));
+        $this->assertEquals([$member->ID], $group->Members()->sort(null)->column('ID'));
     }
 
     public function testCollateAncestorIDs()


### PR DESCRIPTION
Sorting queries can be slow, especially on large datasets and especially if indexes aren't optimised. We should avoid sorting when the sort order doesn't matter.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11833