### PR TITLE
ENH Add note about argument we can't remove.

### DIFF
--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -419,6 +419,9 @@ class Hierarchy extends Extension
             }
         }
         $children = ArrayList::create($childNodes);
+        // $includeDeleted was included by accident but now that it is part of the method signature of the extension
+        // hook we can't remove it for backwards compatibility reasons.
+        $includeDeleted = false;
         $owner->extend('updateGetChildrenForTree', $includeDeleted, $children);
         return $children;
     }


### PR DESCRIPTION
Just adding a note about this both for anyone who wants to use this extension hook, and so we know we can remove it in a future major release.

Setting an explicit value as well since without that it's an unasigned variable which is bad code smell.

## Issue

- https://github.com/silverstripe/silverstripe-lumberjack/issues/203