### PR TITLE
FIX Don't mangle sort columns for aliases of expressions

### DIFF
--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -133,7 +133,7 @@ class DB
      * @param array $parameters Out parameter for the resulting query parameters
      * @param string $name An optional name given to a connection in the DB::setConn() call.  If omitted,
      * the default connection is returned.
-     * @return string The resulting SQL as a string
+     * @return string|null The resulting SQL as a string or null if there's no DB connector or the query was empty
      */
     public static function build_sql(SQLExpression $expression, &$parameters, $name = 'default')
     {

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -394,6 +394,17 @@ class DataQuery
                     continue;
                 }
 
+                // If we're already selecting the value with an expression (for example using a case statement or function call,
+                // which may select values in dynamic ways), just make sure the sort column is quotes and move on.
+                $selects = $query->getSelect();
+                // This regex looks for anything that isn't a single column (with optional table name and ANSI quotes).
+                if (isset($selects[$col]) && !preg_match('/^\s*"?[^.("]+"?\.?"?[^("]*"?\s*$/', $selects[$col])) {
+                    unset($newOrderby[$k]);
+                    $newOrderby['"' . $col . '"'] = $dir;
+                    continue;
+                }
+
+                // Make sure we select the correct column, and both fully qualify and ANSI quote the sort reference.
                 if (count($parts ?? []) == 1) {
                     // Get expression for sort value
                     $qualCol = "\"{$parts[0]}\"";
@@ -410,7 +421,6 @@ class DataQuery
 
                     // To-do: Remove this if block once SQLSelect::$select has been refactored to store getSelect()
                     // format internally; then this check can be part of selectField()
-                    $selects = $query->getSelect();
                     if (!isset($selects[$col]) && !in_array($qualCol, $selects ?? [])) {
                         // Use the original select if possible.
                         if (array_key_exists($col, $originalSelect ?? [])) {

--- a/src/ORM/Queries/SQLExpression.php
+++ b/src/ORM/Queries/SQLExpression.php
@@ -84,7 +84,7 @@ abstract class SQLExpression
      * Generate the SQL statement for this query.
      *
      * @param array $parameters Out variable for parameters required for this query
-     * @return string The completed SQL query
+     * @return string|null The completed SQL query or null if there's no DB connector or the query was empty
      */
     public function sql(&$parameters = [])
     {

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -8,6 +8,8 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\ORM\Tests\DataQueryTest\AugmentSQLExtension;
+use SilverStripe\ORM\Tests\DataQueryTest\ObjectC;
 use SilverStripe\ORM\Tests\DataQueryTest\ObjectE;
 use SilverStripe\Security\Member;
 
@@ -448,7 +450,7 @@ class DataQueryTest extends SapphireTest
         static::resetDBSchema(true);
     }
 
-    public function testAddToQueryIsCalled()
+    public function testFinalisedQueryCallsAddToQuery()
     {
         // Including filter on parent table only doesn't pull in second
         $query = new DataQuery(DataQueryTest\DataObjectAddsToQuery::class);
@@ -461,7 +463,7 @@ class DataQueryTest extends SapphireTest
     /**
      * Tests that getFinalisedQuery can include all tables
      */
-    public function testConditionsIncludeTables()
+    public function testFinalisedQueryCanIncludeAllTables()
     {
         // Including filter on parent table only doesn't pull in second
         $query = new DataQuery(DataQueryTest\ObjectC::class);
@@ -496,6 +498,99 @@ class DataQueryTest extends SapphireTest
         $this->assertNotNull($second);
         $this->assertEquals('Last', $second['Title']);
         $this->assertEmpty(array_shift($arrayResult));
+    }
+
+    public static function provideFinalisedQueryResolvesSortColumns(): array
+    {
+        return [
+            'missing field' => [
+                'selectField' => '',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT "DataQueryTest_C"."Title" FROM "DataQueryTest_C" ORDER BY "DataQueryTest_C"."Title" ASC',
+            ],
+            'missing field (fully qualified sort)' => [
+                'selectField' => '',
+                'sortField' => '"DataQueryTest_C"."Title"',
+                'expectedSQL' => 'SELECT DISTINCT "DataQueryTest_C"."Title" AS "_SortColumn0" FROM "DataQueryTest_C" ORDER BY "_SortColumn0" ASC',
+            ],
+            'select field alone' => [
+                'selectField' => 'Title',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT Title FROM "DataQueryTest_C" ORDER BY "DataQueryTest_C"."Title" ASC',
+            ],
+            'select field alone (ANSI quotes)' => [
+                'selectField' => '"Title"',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT "Title" FROM "DataQueryTest_C" ORDER BY "DataQueryTest_C"."Title" ASC',
+            ],
+            'select field with table' => [
+                'selectField' => 'DataQueryTest_C.Title',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT DataQueryTest_C.Title AS "Title" FROM "DataQueryTest_C" ORDER BY "DataQueryTest_C"."Title" ASC',
+            ],
+            'select field with table (ANSI quotes)' => [
+                'selectField' => '"DataQueryTest_C"."Title"',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT "DataQueryTest_C"."Title" FROM "DataQueryTest_C" ORDER BY "DataQueryTest_C"."Title" ASC',
+            ],
+            'select field with table (ANSI quotes, fully qualified table)' => [
+                'selectField' => '"DataQueryTest_C"."Title"',
+                'sortField' => '"DataQueryTest_C"."Title"',
+                'expectedSQL' => 'SELECT DISTINCT "DataQueryTest_C"."Title" FROM "DataQueryTest_C" ORDER BY "DataQueryTest_C"."Title" ASC',
+            ],
+            'case statement' => [
+                'selectField' => 'CASE WHEN "DataQueryTest_C"."ID" IS NOT NULL THEN "DataQueryTest_C"."Title" ELSE \'this value\' END',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT CASE WHEN "DataQueryTest_C"."ID" IS NOT NULL THEN "DataQueryTest_C"."Title" ELSE \'this value\' END AS "Title"'
+                    . ' FROM "DataQueryTest_C" ORDER BY "Title" ASC',
+            ],
+            'SQL function call' => [
+                'selectField' => 'CONCAT("DataQueryTest_C"."Title",\'something\')',
+                'sortField' => 'Title',
+                'expectedSQL' => 'SELECT DISTINCT CONCAT("DataQueryTest_C"."Title",\'something\') AS "Title" FROM "DataQueryTest_C" ORDER BY "Title" ASC',
+            ],
+            'SQL function call (fully qualified sort)' => [
+                'selectField' => 'CONCAT("DataQueryTest_C"."Title",\'something\')',
+                'sortField' => '"DataQueryTest_C"."Title"',
+                'expectedSQL' => 'SELECT DISTINCT CONCAT("DataQueryTest_C"."Title",\'something\') AS "Title", "DataQueryTest_C"."Title" AS "_SortColumn0" FROM "DataQueryTest_C" ORDER BY "_SortColumn0" ASC',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFinalisedQueryResolvesSortColumns
+     * See also testCustomFieldWithAliasSort
+     */
+    public function testFinalisedQueryResolvesSortColumns(string $selectField, string $sortField, string $expectedSQL): void
+    {
+        ObjectC::add_extension(AugmentSQLExtension::class);
+        AugmentSQLExtension::setAugmentCallback(function (SQLSelect $select) use ($selectField) {
+            if ($selectField) {
+                $select->selectField($selectField, 'Title');
+            } else {
+                $selectFields = $select->getSelect();
+                unset($selectFields['Title']);
+                $select->setSelect($selectFields);
+            }
+        });
+        $query = new DataQuery(DataQueryTest\ObjectC::class);
+        $query->sort($sortField);
+        $finalisedQuery = $query->getFinalisedQuery();
+
+        // Remove unnecessary fields so the expected SQL can be more succinct
+        $selectFields = $finalisedQuery->getSelect();
+        unset($selectFields['RecordClassName']);
+        unset($selectFields['ClassName']);
+        unset($selectFields['LastEdited']);
+        unset($selectFields['Created']);
+        unset($selectFields['ID']);
+        unset($selectFields['TestAID']);
+        unset($selectFields['TestBID']);
+        $finalisedQuery->setSelect($selectFields);
+
+        // Normalise whitespace to a single space
+        $sql = preg_replace('/\s{2,}/', ' ', $finalisedQuery->sql());
+        $this->assertSame($expectedSQL, $sql);
     }
 
     public function testColumnReturnsAllValues()

--- a/tests/php/ORM/DataQueryTest/AugmentSQLExtension.php
+++ b/tests/php/ORM/DataQueryTest/AugmentSQLExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+class AugmentSQLExtension extends Extension implements TestOnly, Resettable
+{
+    // Not allowed to use callable type for properties
+    private static mixed $augmentCallback = null;
+
+    public static function setAugmentCallback(?callable $augmentCallback): void
+    {
+        AugmentSQLExtension::$augmentCallback = $augmentCallback;
+    }
+
+    public static function reset()
+    {
+        AugmentSQLExtension::$augmentCallback = null;
+    }
+
+    protected function augmentSQL(SQLSelect $select, DataQuery $query): void
+    {
+        if (AugmentSQLExtension::$augmentCallback !== null) {
+            call_user_func_array(AugmentSQLExtension::$augmentCallback, [$select, $query]);
+        }
+    }
+}


### PR DESCRIPTION
If we're selecting for a field using an expression, we should sort by the alias of the selected expression explicitly, not by the full table.column name.

For example with the test steps below, the select expression looks like this:

```SQL
SELECT DISTINCT (
  CASE WHEN "File_Localised_nz_nz"."ID" IS NOT NULL THEN "File_Localised_en_nz"."Title"
  ELSE "File"."Title" END
) AS "Title"
ORDER BY "File"."Title" ASC;
```

Since we're not selecting `"File"."Title"` directly this fails - we should just be sorting by `"Title" ASC` instead, using the alias of the full case statement.

We could instead add `"File"."Title"` to the selection, but that could cause problems with filtering and would result in always sorting by the non-localised field in this example scenario.

## Test steps

The easiest way to test this is with fluent.

1. install tractorcow/silverstripe-fluent
    `composer require tractorcow/silverstripe-fluent && sake dev/build`
1. Add the YAML snippet from the "how to reproduce" section of the linked issue. This will add fluent to your files.
1. Add a locale either programatically or through `/admin/locales`
    ````php
    use TractorCow\Fluent\Model\Locale;
    Locale::create([
            'Title' => 'en',
            'Locale' => 'en_nz',
            'URLSegment' => '/',
            'IsGlobalDefault' => true,
        ])->write();
    ```
1. Go to `/admin/assets`
2. Click on the sort dropdown and select "Title Z-A"
    <img width="210" height="203" alt="image" src="https://github.com/user-attachments/assets/c78db890-329d-4385-87c6-31811dfe6992" />

Without this PR the graphql query should fail with a server error. With this PR the query should work as expected.

For bonus points, add a second locale, upload some files, change the title of one of the files in one locale, and observe the sort order working correctly in both locales based on the title (after selecting the sort order with the dropdown).

## Issue

- https://github.com/tractorcow-farm/silverstripe-fluent/issues/1005