### PR TITLE
ENH Improve performance of Hierarchy::duplicateWithChildren()

### DIFF
--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -303,21 +303,13 @@ class Hierarchy extends Extension
     {
         $owner = $this->getOwner();
         $clone = $owner->duplicate();
-        $children = $owner->AllChildren();
-        $sortField = $owner->getSortField();
-
-        $sort = 1;
+        // Disabling sort improves performance
+        $children = $owner->AllChildren()->sort(null);
         foreach ($children as $child) {
             $childClone = $child->duplicateWithChildren();
             $childClone->ParentID = $clone->ID;
-            if ($sortField) {
-                //retain sort order by manually setting sort values
-                $childClone->$sortField = $sort;
-                $sort++;
-            }
             $childClone->write();
         }
-
         return $clone;
     }
 

--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -591,13 +591,13 @@ class HierarchyTest extends SapphireTest
         $child1 = new HierarchyTest\SortableHierarchyModel();
         $child1->ParentID = $parent->ID;
         $child1->Title = 'Child 1';
-        $child1->Sort = 2;
+        $child1->Sort = 7;
         $child1->write();
 
         $child2 = new HierarchyTest\SortableHierarchyModel();
         $child2->ParentID = $parent->ID;
         $child2->Title = 'Child 2';
-        $child2->Sort = 1;
+        $child2->Sort = 3;
         $child2->write();
 
         $duplicateParent = $parent->duplicateWithChildren();
@@ -612,6 +612,10 @@ class HierarchyTest extends SapphireTest
         $this->assertEquals($child2->Title, $duplicateChild2->Title);
         $this->assertNotEquals($duplicateChild1->ID, $child1->ID);
         $this->assertNotEquals($duplicateChild2->ID, $child2->ID);
+
+        // Sort values match the original records
+        $this->assertSame($child1->Sort, $duplicateChild1->Sort);
+        $this->assertSame($child2->Sort, $duplicateChild2->Sort);
 
         // assertGreaterThan works by having the LOWER value first
         $this->assertGreaterThan($duplicateChild2->Sort, $duplicateChild1->Sort);


### PR DESCRIPTION
Note that:

1. The bug described in https://github.com/silverstripe/silverstripe-cms/pull/1636 is still fixed (the sort values aren't all identical, the children don't "jump around on save", and the test added in that PR is still passing)
2. While the sort value for the duplicated children will be different to the sort value they would have without this PR, the sort _order_ is correct which is the important thing.
3. Arguably this is a bug fix, since duplicating a record should generally retain the values, not change them.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11839