### PR TITLE
ENH Hide font icons from screen readers

### DIFF
--- a/templates/SilverStripe/Forms/GridField/GridFieldAddNewButton.ss
+++ b/templates/SilverStripe/Forms/GridField/GridFieldAddNewButton.ss
@@ -1,3 +1,4 @@
-<a href="$NewLink" class="action action-detail btn btn-primary font-icon-plus-circled new new-link">
+<a href="$NewLink" class="action action-detail btn btn-primary new new-link">
+    <span class="font-icon-plus-circled" aria-hidden="true"></span>
     <span class="btn__title">$ButtonName</span>
 </a>

--- a/templates/SilverStripe/Forms/GridField/GridFieldViewButton.ss
+++ b/templates/SilverStripe/Forms/GridField/GridFieldViewButton.ss
@@ -1,3 +1,4 @@
-<a class="grid-field__icon-action font-icon-right-open btn--icon-large action action-detail view-link action-menu--handled" href="$Link">
+<a class="grid-field__icon-action btn--icon-large action action-detail view-link action-menu--handled" href="$Link">
+    <span class="font-icon-right-open" aria-hidden="true"></span>
     <span class="visually-hidden">View</span>
 </a>

--- a/templates/SilverStripe/ORM/Search/SearchContextForm_Button.ss
+++ b/templates/SilverStripe/ORM/Search/SearchContextForm_Button.ss
@@ -1,9 +1,11 @@
 <div class="view-controls">
     <% if not $IsFiltered %>
         <button type="button" name="showFilter" aria-controls="$HTMLID"
-            class="btn btn-secondary icon-button font-icon-search btn--icon-large btn--no-text"
+            class="btn btn-secondary icon-button btn--icon-large btn--no-text"
             title="<%t SilverStripe\ORM\Search\SearchContextForm.OpenFilter 'Open search and filter' %>"
             aria-label="<%t SilverStripe\ORM\Search\SearchContextForm.OpenFilter 'Open search and filter' %>"
-        ></button>
+        >
+            <span class="font-icon-search" aria-hidden="true"></span>
+        </button>
     <% end_if %>
 </div>

--- a/templates/SilverStripe/Security/CMSSecurity_login.ss
+++ b/templates/SilverStripe/Security/CMSSecurity_login.ss
@@ -15,7 +15,7 @@
         <div class="cms-security__container container fill-height">
             <div class="row">
                 <h1>
-                    <span class="icon font-icon-back-in-time"></span>
+                    <span class="icon font-icon-back-in-time" aria-hidden="true"></span>
                     <%t SilverStripe\\Security\\CMSSecurity.LOGIN_TITLE 'Return to where you left off by logging back in' %>
                 </h1>
             </div>

--- a/templates/SilverStripe/Security/CMSSecurity_success.ss
+++ b/templates/SilverStripe/Security/CMSSecurity_success.ss
@@ -8,7 +8,7 @@
 		<div class="cms-security__container container fill-height">
             <div class="row">
                 <h1>
-                    <span class="icon font-icon-back-in-time"></span>
+                    <span class="icon font-icon-back-in-time" aria-hidden="true"></span>
                     <%t SilverStripe\\Security\\CMSSecurity.SUCCESS_TITLE 'Login successful' %>
                 </h1>
             </div>


### PR DESCRIPTION
- Hides decorative icons from screen readers (usually by adding an inner `span`)

Without the admin PR things look very slightly different, but it's still perfectly usable so I don't think it's worth adding a conflict.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957