### PR TITLE
ENH Remove gridfield action column when there are no action items

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -27,6 +27,7 @@ use SilverStripe\Model\ModelData;
 use SilverStripe\Security\SudoMode\SudoModeServiceInterface;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Forms\GridField\GridFieldViewButton;
+use SilverStripe\Forms\GridField\GridField_ActionMenu;
 
 /**
  * Displays a {@link SS_List} in a grid format.
@@ -561,8 +562,14 @@ class GridField extends FormField
             }
         }
 
-        $columns = $this->getColumns();
+        // Conditionally filter out components before rendering them
+        foreach ($this->getComponents() as $component) {
+            if (is_a($component, GridField_ActionMenu::class) && empty($component->getItems($this))) {
+                $this->config->removeComponentsByType(GridField_ActionMenu::class);
+            }
+        }
 
+        $columns = $this->getColumns();
         $list = $this->getManipulatedList();
         $total = null; // can be populated by GridFieldPaginator
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11817

This only half fixes the issue. Given the extra complexity of the JS side of this adds, I'm going to pause work on this one and pick up something else that's a quicker win. This one kind of feels like an issue with tech-debt, partially due to not using a react GridField. Have an empty column doesn't seem that bad IMO in the scheme of things, so not worth the effort to fix IMO.

I'll leave this PR here closed in case someone wants to pick this work up later, feel free to copy paste from this PR

While this PR fixes things on the PHP side pretty efficiently and removes the `<th>` + `<td>` columns when then don't need to be there, there's some pretty rough JS that then hacks in a `<th>` that shouldn't be there
- https://github.com/silverstripe/silverstripe-admin/blob/3/client/src/legacy/GridField.js#L172
- https://github.com/silverstripe/silverstripe-gridfieldextensions/blob/5/javascript/GridFieldExtensions.js#L351

