### PR TITLE
FIX Fix flushing in live and test modes

### DIFF
--- a/src/Control/Middleware/URLSpecialsMiddleware.php
+++ b/src/Control/Middleware/URLSpecialsMiddleware.php
@@ -17,8 +17,6 @@ use SilverStripe\Security\RandomGenerator;
  *
  * The rules are:
  *  - flush GET parameter
- *  - isDev GET parameter
- *  - isTest GET parameter
  *  - dev/build URL
  *
  * @see https://docs.silverstripe.org/en/developer_guides/debugging/url_variable_tools/ special variables docs

--- a/src/Control/Middleware/URLSpecialsMiddleware/FlushScheduler.php
+++ b/src/Control/Middleware/URLSpecialsMiddleware/FlushScheduler.php
@@ -27,7 +27,7 @@ trait FlushScheduler
      */
     public function scheduleFlush(HTTPRequest $request)
     {
-        if ($request->getURL() === 'dev/build') {
+        if (array_key_exists('flush', $request->getVars()) || $request->getURL() === 'dev/build') {
             $kernel = Injector::inst()->get(Kernel::class);
             if (!$kernel->isFlushed()) {
                 ScheduledFlushDiscoverer::scheduleFlush($kernel);


### PR DESCRIPTION
The flush param used to be checked here [in CMS 5](https://github.com/silverstripe/silverstripe-framework/blob/5.4/src/Control/Middleware/URLSpecialsMiddleware/FlushScheduler.php) but was removed in https://github.com/silverstripe/silverstripe-framework/pull/11440 to resolve https://github.com/silverstripe/.github/issues/324.

Note that the param _is explicitly needed_ here, because `RequestFlushDiscoverer` (the way `?flush` is detected in dev mode) explicitly only tells the kernel to flush when in dev mode - so scheduling the flush here based on the flush get param is the only way to actually make flushing happen via a GET request in live/test mode.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11841