### PR TITLE
ENH Update text for GridFieldAddNewButton

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -143,6 +143,7 @@ en:
     TABMAIN: Main
   SilverStripe\Forms\GridField\GridField:
     Add: 'Add {name}'
+    AddNew: 'Add new {name}'
     CSVEXPORT: 'Export to CSV'
     CSVIMPORT: 'Import CSV'
     Filter: Filter

--- a/src/Forms/GridField/GridFieldAddNewButton.php
+++ b/src/Forms/GridField/GridFieldAddNewButton.php
@@ -62,7 +62,7 @@ class GridFieldAddNewButton extends AbstractGridFieldComponent implements GridFi
         if (!$this->buttonName) {
             // provide a default button name, can be changed by calling {@link setButtonName()} on this component
             $objectName = $singleton->hasMethod('i18n_singular_name') ? $singleton->i18n_singular_name() : ClassInfo::shortName($singleton);
-            $this->buttonName = _t('SilverStripe\\Forms\\GridField\\GridField.Add', 'Add {name}', ['name' => $objectName]);
+            $this->buttonName = _t('SilverStripe\\Forms\\GridField\\GridField.AddNew', 'Add new {name}', ['name' => $objectName]);
         }
 
         $data = new ArrayData([


### PR DESCRIPTION

## Description
Renamed the GridFieldAddNewButton text from "Add {obj}" to "Add new {obj}". Also updated lang/en.yml to introduce a new localisation key.


## Manual testing steps

## Issues
- #9980 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green

PR was made during the StripeCon hackathon.