### PR TITLE
ENH Don't write session data with incorrect perms

### DIFF
--- a/src/Control/SessionHandler/FileSessionHandler.php
+++ b/src/Control/SessionHandler/FileSessionHandler.php
@@ -163,12 +163,15 @@ class FileSessionHandler extends AbstractSessionHandler
         $path = $this->getFilePath($id);
         $filesystem = new Filesystem();
 
-        // Save file contents
-        try {
-            $filesystem->dumpFile($path, $data);
-        } catch (IOException $e) {
-            $this->logError('Could not write to session file: ' . $this->getSafeExceptionMessage($e, $id));
-            return false;
+        // Create the file if it doesn't exist
+        // We do this without data initially so an attacker doesn't have access to session data with potentially invalid permissions
+        if (!$filesystem->exists($path)) {
+            try {
+                $filesystem->dumpFile($path, '');
+            } catch (IOException $e) {
+                $this->logError('Could not create session file: ' . $this->getSafeExceptionMessage($e, $id));
+                return false;
+            }
         }
 
         // Set file permissions
@@ -179,6 +182,14 @@ class FileSessionHandler extends AbstractSessionHandler
                 $this->logError('Could not set permissions for session file: ' . $this->getSafeExceptionMessage($e, $id));
                 return false;
             }
+        }
+
+        // Save file contents
+        try {
+            $filesystem->dumpFile($path, $data);
+        } catch (IOException $e) {
+            $this->logError('Could not write to session file: ' . $this->getSafeExceptionMessage($e, $id));
+            return false;
         }
 
         return true;


### PR DESCRIPTION
> [!NOTE]
> Targetting `6.1` instead of `6` because this is a security enhancement with no change to API. It's safe for a patch.

An alternative solution would be to use [`umask()`](https://www.php.net/manual/en/function.umask.php) to set default permissions before dumpting the data into the file. That would technically be better since there's _no_ time when there's a file with the wrong permissions. However, PHP warns against using `umask()` in multithreaded webservers. Since we don't control the webserver or hosting we shouldn't use `umask()`.

Instead, we now create an empty file, then change permissions if needed, _then_ write the data into the file. There is still a window while the file may have the wrong permissions, but there's no data in the file during that window. It's an additional file operation when initially creating the session file but the performance impact of that is negligible.

This also means if file permissions change in php.ini settings, we update the perms before writing new session data which is the technically correct way to go about that.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11865