### PR TITLE
FIX Use tmp dir if session.save_path is empty

### DIFF
--- a/src/Control/SessionHandler/FileSessionHandler.php
+++ b/src/Control/SessionHandler/FileSessionHandler.php
@@ -232,6 +232,10 @@ class FileSessionHandler extends AbstractSessionHandler
      */
     private function setSavePath(string $path): void
     {
+        // If session.save-path is empty, we should use the tmp dir.
+        if (!$path) {
+            $path = sys_get_temp_dir();
+        }
         // Handle configuration for depth and mode arguments
         // $path can have up to two optional params ending with semi-colon defining
         // 1) the number of subdirs and 2) the octal mode e.g. N;MODE;/path

--- a/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
@@ -36,6 +36,10 @@ class FileSessionHandlerTest extends SapphireTest
     public static function provideOpen(): array
     {
         return [
+            'empty string path' => [
+                'path' => '',
+                'expected' => true,
+            ],
             'valid path on its own' => [
                 'path' => static::$sessionSavePath,
                 'expected' => true,
@@ -62,6 +66,12 @@ class FileSessionHandlerTest extends SapphireTest
     public static function provideSetSavePath(): array
     {
         return [
+            'empty string path' => [
+                'sessionSavePath' => '',
+                'baseDir' => sys_get_temp_dir(),
+                'numSubDirs' => 0,
+                'mode' => 0600,
+            ],
             'just a path' => [
                 'sessionSavePath' => static::$sessionSavePath,
                 'baseDir' => static::$sessionSavePath,


### PR DESCRIPTION
Using the temp dir is the behaviour of the built-in session handler when the save_path is empty. See https://www.php.net/manual/en/session.configuration.php#ini.session.save-path

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11872