### PR TITLE
FIX Don't render empty actions column in GridField

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -701,11 +701,10 @@ class GridField extends FormField
 
                 $rowContent = '';
 
-                foreach ($this->getColumns() as $column) {
+                foreach ($columns as $column) {
                     $colContent = $this->getColumnContent($record, $column);
 
                     // Null means this columns should be skipped altogether.
-
                     if ($colContent === null) {
                         continue;
                     }
@@ -1117,11 +1116,7 @@ class GridField extends FormField
      */
     public function getColumnCount()
     {
-        if (!$this->columnDispatch) {
-            $this->buildColumnDispatch();
-        }
-
-        return count($this->columnDispatch ?? []);
+        return count($this->getColumns());
     }
 
     /**

--- a/src/Forms/GridField/GridFieldFooter.php
+++ b/src/Forms/GridField/GridFieldFooter.php
@@ -66,7 +66,7 @@ class GridFieldFooter extends AbstractGridFieldComponent implements GridField_HT
             'footer' => $forTemplate->renderWith(
                 $template,
                 [
-                    'Colspan' => count($gridField->getColumns() ?? [])
+                    'Colspan' => $gridField->getColumnCount(),
                 ]
             )
         ];

--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -303,7 +303,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
         return [
             'footer' => $forTemplate->renderWith(
                 $template,
-                ['Colspan' => count($gridField->getColumns() ?? [])]
+                ['Colspan' => $gridField->getColumnCount()]
             )
         ];
     }

--- a/src/Forms/GridField/GridField_ActionMenu.php
+++ b/src/Forms/GridField/GridField_ActionMenu.php
@@ -12,7 +12,7 @@ class GridField_ActionMenu extends AbstractGridFieldComponent implements GridFie
 {
     public function augmentColumns($gridField, &$columns)
     {
-        if (!in_array('Actions', $columns ?? [])) {
+        if (!in_array('Actions', $columns ?? []) && $this->getItems($gridField)) {
             $columns[] = 'Actions';
         }
     }


### PR DESCRIPTION
A few things changing here:

1. Don't add the column in `augmentColumns()` if we have no actions
1. Fix column count to use the actual column array
1. Ensure column count is used consistently (for things like colspans)

## Issue

- https://github.com/silverstripe/silverstripe-admin/pull/2020