### PR TITLE
ENH Add icon property to Tab

### DIFF
--- a/src/Forms/Tab.php
+++ b/src/Forms/Tab.php
@@ -40,6 +40,11 @@ class Tab extends CompositeField
     protected $id;
 
     /**
+     * Identifier of icon, if supported on the frontend
+     */
+    private string $icon = '';
+
+    /**
      * @uses FormField::name_to_label()
      *
      * @param string $name Identifier of the tab, without characters like dots or spaces
@@ -106,6 +111,25 @@ class Tab extends CompositeField
             $this->setID(Convert::raw2htmlid($name));
         }
         return parent::setName($name);
+    }
+
+    /**
+     * Get button icon, if supported
+     */
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    /**
+     * Sets button icon
+     *
+     * @param string $icon Icon identifier (not path)
+     */
+    public function setIcon(string $icon)
+    {
+        $this->icon = $icon;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
For now this is useful for the "More Options" tab in the save/publish/etc action area in the CMS but should be expanded for other tabs in the CMS as well.

Note that any front-end usage is the responsibility of project developers, given that we have no idea how they want to add icons. For context, calling `setIcon()` on a `FormAction` (which is what inspired this change) doesn't affect the markdown for `FormAction` on the front-end by default.

Used in these PRs:

- https://github.com/silverstripe/silverstripe-cms/pull/3125
- https://github.com/silverstripe/silverstripe-versioned/pull/528

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957