### PR TITLE
FIX Improve validation performance for searchable dropdowns

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -603,4 +603,9 @@ trait SearchableDropdownTrait
 
         return $field;
     }
+
+    protected function getSourceValues()
+    {
+        return $this->sourceList->sort(null)->column('ID');
+    }
 }


### PR DESCRIPTION
Went with the first option in https://github.com/silverstripe/silverstripe-framework/issues/11879#issuecomment-3404398464.

Using the same data that Steve was using, the validation time goes from 22 seconds before this PR to ~200ms after this PR locally.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11879