### PR TITLE
FIX Set params on BasicSearchContext when querying

### DIFF
--- a/src/ORM/Search/BasicSearchContext.php
+++ b/src/ORM/Search/BasicSearchContext.php
@@ -81,6 +81,7 @@ class BasicSearchContext extends SearchContext
 
     private function applySearchFilters(array $searchParams): array
     {
+        $this->setSearchParams($searchParams);
         $applied = [];
         foreach ($searchParams as $fieldName => $searchTerm) {
             // Ignore the general search field - we'll deal with that in a special way.


### PR DESCRIPTION
`GridFieldFilterHeader::getHTMLFragments()` relies on search params having been set in the search context for some things - and the form itself also pulls data from the search context based on those filters.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/2019