### PR TITLE
FIX Allow default value and other options in DBFields

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -412,7 +412,6 @@ abstract class DBSchemaManager
                 if ($pos !== false) {
                     //If so, remove it and store that info separately
                     $arrayValue = substr($fieldSpec, $pos);
-                    $fieldSpec = substr($fieldSpec, 0, $pos);
                 }
 
                 /** @var DBField $fieldObj */

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use SilverStripe\Dev\Deprecation;
+
 /**
  * Represents a classname selector, which respects obsolete clasess.
  */
@@ -20,10 +22,26 @@ class DBClassName extends DBEnum
         return $spec;
     }
 
+    /**
+     * @inheritDoc
+     * @deprecated 6.2.0 Use getDefaultValue() instead.
+     */
     public function getDefault(): string
     {
+        Deprecation::notice('6.2.0', 'Use getDefaultValue() instead.');
         // Check for assigned default
         $default = parent::getDefault();
+        if ($default) {
+            return $default;
+        }
+
+        return $this->getDefaultClassName();
+    }
+
+    public function getDefaultValue(): mixed
+    {
+        // Check for assigned default
+        $default = parent::getDefaultValue();
         if ($default) {
             return $default;
         }

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -77,10 +77,10 @@ class DBEnum extends DBString implements Resettable
             $this->setEnum($enum);
             $enum = $this->getEnum();
 
-            // If there's a default, then use this
+            // If there's a default, then use it
             if ($default && !is_int($default)) {
                 if (in_array($default, $enum)) {
-                    $this->setDefault($default);
+                    $options['default'] = $default;
                 } else {
                     throw new \InvalidArgumentException(
                         "Enum::__construct() The default value '$default' does not match any item in the enumeration"
@@ -88,10 +88,10 @@ class DBEnum extends DBString implements Resettable
                 }
             } elseif (is_int($default) && $default < count($enum)) {
                 // Set to specified index if given
-                $this->setDefault($enum[$default]);
+                $options['default'] = $enum[$default];
             } else {
                 // Set to null if specified
-                $this->setDefault(null);
+                $options['default'] = null;
             }
         }
 
@@ -252,6 +252,20 @@ class DBEnum extends DBString implements Resettable
     {
         $this->default = $default;
         $this->setDefaultValue($default);
+        return $this;
+    }
+
+    public function setOptions(array $options = []): static
+    {
+        parent::setOptions($options);
+
+        if (array_key_exists('default', $options)) {
+            if ($this->getNullifyEmpty() && $this->isEmptyValue($options['default'])) {
+                $options['default'] = null;
+            }
+            $this->setDefault($options['default']);
+        }
+
         return $this;
     }
 }

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\SelectField;
 use SilverStripe\Core\ArrayLib;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DB;
 use SilverStripe\Model\ModelData;
@@ -33,6 +34,7 @@ class DBEnum extends DBString implements Resettable
 
     /**
      * Default value
+     * @deprecated 6.2.0 Use setDefaultValue() and getDefaultValue() instead.
      */
     protected ?string $default = null;
 
@@ -116,7 +118,7 @@ class DBEnum extends DBString implements Resettable
             'enums' => $this->getEnumObsolete(),
             'character set' => $charset,
             'collate' => $collation,
-            'default' => $this->getDefault(),
+            'default' => $this->getDefaultValue(),
             'table' => $this->getTable(),
             'arrayValue' => $this->arrayValue
         ];
@@ -239,33 +241,23 @@ class DBEnum extends DBString implements Resettable
 
     /**
      * Get default value
+     * @deprecated 6.2.0 Use getDefaultValue() instead.
      */
     public function getDefault(): ?string
     {
-        return $this->default;
+        Deprecation::notice('6.2.0', 'Use getDefaultValue() instead.');
+        return $this->default ?? $this->getDefaultValue();
     }
 
     /**
      * Set default value
+     * @deprecated 6.2.0 Use setDefaultValue() instead.
      */
     public function setDefault(?string $default): static
     {
+        Deprecation::notice('6.2.0', 'Use setDefaultValue() instead.');
         $this->default = $default;
         $this->setDefaultValue($default);
-        return $this;
-    }
-
-    public function setOptions(array $options = []): static
-    {
-        parent::setOptions($options);
-
-        if (array_key_exists('default', $options)) {
-            if ($this->getNullifyEmpty() && $this->isEmptyValue($options['default'])) {
-                $options['default'] = null;
-            }
-            $this->setDefault($options['default']);
-        }
-
         return $this;
     }
 }

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Model\ModelData;
 use SilverStripe\Core\Validation\FieldValidation\FieldValidationTrait;
 use SilverStripe\Core\Validation\FieldValidation\FieldValidationInterface;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Single field in the database.
@@ -65,6 +66,8 @@ abstract class DBField extends ModelData implements DBIndexable, FieldValidation
     /**
      * Used for generating DB schema. {@see DBSchemaManager}
      * Despite its name, this seems to be a string
+     *
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it in a future major release.
      */
     protected $arrayValue;
 
@@ -531,13 +534,21 @@ DBG;
         return (string)$this->forTemplate();
     }
 
+    /**
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it in a future major release.
+     */
     public function getArrayValue()
     {
+        Deprecation::noticeWithNoReplacment('6.2.0');
         return $this->arrayValue;
     }
 
+    /**
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it in a future major release.
+     */
     public function setArrayValue($value): static
     {
+        Deprecation::noticeWithNoReplacment('6.2.0');
         $this->arrayValue = $value;
         return $this;
     }

--- a/src/ORM/FieldType/DBGenerated.php
+++ b/src/ORM/FieldType/DBGenerated.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\FieldType;
 use InvalidArgumentException;
 use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\DB;
@@ -126,8 +127,12 @@ class DBGenerated extends DBField
         return $this->getChildField()->getValue();
     }
 
+    /**
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it in a future major release.
+     */
     public function getArrayValue()
     {
+        Deprecation::noticeWithNoReplacment('6.2.0');
         return $this->getChildField()->getArrayValue();
     }
 
@@ -142,8 +147,12 @@ class DBGenerated extends DBField
         return parent::setValue($value, $record, $markChanged);
     }
 
+    /**
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it in a future major release.
+     */
     public function setArrayValue($value): static
     {
+        Deprecation::noticeWithNoReplacment('6.2.0');
         $this->getChildField()->setArrayValue($value);
         return parent::setArrayValue($value);
     }

--- a/src/ORM/FieldType/DBString.php
+++ b/src/ORM/FieldType/DBString.php
@@ -30,8 +30,13 @@ abstract class DBString extends DBField
      */
     public function __construct($name = null, $options = [])
     {
-        $this->options['nullifyEmpty'] = true;
-        $this->options['default'] = '';
+        $options = is_array($options) ? $options : [];
+        if (!array_key_exists('nullifyEmpty', $options)) {
+            $options['nullifyEmpty'] = true;
+        }
+        if (!array_key_exists('default', $options)) {
+            $options['default'] = '';
+        }
         parent::__construct($name, $options);
     }
 
@@ -49,10 +54,13 @@ abstract class DBString extends DBField
     {
         parent::setOptions($options);
 
-        if (array_key_exists('nullifyEmpty', $options ?? [])) {
+        if (array_key_exists('nullifyEmpty', $options)) {
             $this->options['nullifyEmpty'] = (bool) $options['nullifyEmpty'];
         }
-        if (array_key_exists('default', $options ?? [])) {
+        if (array_key_exists('default', $options)) {
+            if ($this->getNullifyEmpty() && $this->isEmptyValue($options['default'])) {
+                $options['default'] = null;
+            }
             $this->setDefaultValue($options['default']);
         }
 
@@ -93,7 +101,7 @@ abstract class DBString extends DBField
     public function prepValueForDB(mixed $value): array|string|null
     {
         // Cast non-empty value
-        if (is_scalar($value) && strlen($value ?? '')) {
+        if (!$this->isEmptyValue($value)) {
             return (string)$value;
         }
 
@@ -102,6 +110,21 @@ abstract class DBString extends DBField
             return null;
         }
         return '';
+    }
+
+    public function writeToManipulation(array &$manipulation): void
+    {
+        // If we're not nullifying empty, the empty string should be passed to the database as-is.
+        if (!$this->getNullifyEmpty() && $this->getValue() === '') {
+            $manipulation['fields'][$this->name] = '';
+        } else {
+            parent::writeToManipulation($manipulation);
+        }
+    }
+
+    protected function isEmptyValue(mixed $value): bool
+    {
+        return !is_scalar($value) || strlen($value ?? '') === 0;
     }
 
     public function forTemplate(): string

--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -59,8 +59,8 @@ class DBText extends DBString
             'datatype' => 'mediumtext',
             'character set' => $charset,
             'collate' => $collation,
-            'default' => $this->defaultVal,
-            'arrayValue' => $this->arrayValue
+            'default' => $this->getDefaultValue(),
+            'arrayValue' => $this->arrayValue,
         ];
 
         return [

--- a/src/ORM/FieldType/DBVarchar.php
+++ b/src/ORM/FieldType/DBVarchar.php
@@ -82,12 +82,13 @@ class DBVarchar extends DBString
             'precision' => $this->size,
             'character set' => $charset,
             'collate' => $collation,
-            'arrayValue' => $this->arrayValue
+            'arrayValue' => $this->arrayValue,
+            'default' => $this->getDefaultValue(),
         ];
 
         return [
             'type' => 'varchar',
-            'parts' => $parts
+            'parts' => $parts,
         ];
     }
 

--- a/tests/php/ORM/DBFieldTest.php
+++ b/tests/php/ORM/DBFieldTest.php
@@ -58,6 +58,7 @@ use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
 use SilverStripe\ORM\FieldType\DBClassNameVarchar;
 use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
 use SilverStripe\Core\Validation\FieldValidation\NumericNonStringFieldValidator;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBGenerated;
 
 /**
@@ -424,12 +425,14 @@ class DBFieldTest extends SapphireTest
 
     public function testDefaultValues(): void
     {
+        $dataObjectClasses = ClassInfo::subclassesFor(DataObject::class, false);
         $expectedBaseDefault = null;
         $expectedDefaults = [
             DBBoolean::class => false,
             DBDecimal::class => 0.0,
             DBInt::class => 0,
             DBFloat::class => 0.0,
+            DBClassName::class => $dataObjectClasses[array_key_first($dataObjectClasses)],
         ];
         $count = 0;
         $classes = ClassInfo::subclassesFor(DBField::class);

--- a/tests/php/ORM/DBVarcharTest.php
+++ b/tests/php/ORM/DBVarcharTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\Tests;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\NullableField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\FieldType\DBVarchar;
 
 class DBVarcharTest extends SapphireTest
 {
@@ -15,16 +16,59 @@ class DBVarcharTest extends SapphireTest
     public function testScaffold()
     {
         $obj = new DBVarcharTest\TestObject();
+        /** @var DBVarchar $dbField */
+        $dbField = $obj->dbObject('Title');
+        $this->assertTrue($dbField->getNullifyEmpty());
         /** @var TextField $field */
-        $field = $obj->dbObject('Title')->scaffoldFormField();
+        $field = $dbField->scaffoldFormField();
         $this->assertInstanceOf(TextField::class, $field);
         $this->assertEquals(129, $field->getMaxLength());
 
+        /** @var DBVarchar $dbField */
+        $dbField = $obj->dbObject('NullableField');
+        $this->assertFalse($dbField->getNullifyEmpty());
         /** @var NullableField $nullable */
-        $nullable = $obj->dbObject('NullableField')->scaffoldFormField();
+        $nullable = $dbField->scaffoldFormField();
         $this->assertInstanceOf(NullableField::class, $nullable);
         $innerField = $nullable->valueField;
         $this->assertInstanceOf(TextField::class, $innerField);
         $this->assertEquals(111, $innerField->getMaxLength());
+    }
+
+    public function testDefaultValue()
+    {
+        $obj = new DBVarcharTest\TestObject();
+        $id = $obj->write();
+        // Note that the defalt value comes from the database, so it will be
+        // on the record when we fetch it, not on the above $obj object.
+        $record = DBVarcharTest\TestObject::get()->byID($id);
+        $this->assertSame('default value', $record->HasDefault);
+        $this->assertSame('default value', $record->HasDefaultOldSyntax);
+    }
+
+    public function testNullifyEmpty(): void
+    {
+        $obj = new DBVarcharTest\TestObject();
+        $id = $obj->write();
+        $record = DBVarcharTest\TestObject::get()->byID($id);
+        // Default values
+        $this->assertSame(null, $record->Title, 'Title should be null');
+        $this->assertSame('', $record->NullableField, 'NullableField should be empty string');
+
+        // Setting values to empty string - only title should be nullified
+        $record->Title = '';
+        $record->NullableField = '';
+        $record->write();
+        $record = DBVarcharTest\TestObject::get()->byID($id);
+        $this->assertSame(null, $record->Title, 'Title should be null');
+        $this->assertSame('', $record->NullableField, 'NullableField should be empty string');
+
+        // Setting values to null - both should be null
+        $record->Title = null;
+        $record->NullableField = null;
+        $record->write();
+        $record = DBVarcharTest\TestObject::get()->byID($id);
+        $this->assertSame(null, $record->Title, 'Title should be null');
+        $this->assertSame(null, $record->NullableField, 'NullableField should be null');
     }
 }

--- a/tests/php/ORM/DBVarcharTest/TestObject.php
+++ b/tests/php/ORM/DBVarcharTest/TestObject.php
@@ -11,6 +11,8 @@ class TestObject extends DataObject implements TestOnly
 
     private static $db = [
         'Title' => 'Varchar(129)',
-        'NullableField' => 'Varchar(111, ["nullifyEmpty" => false])'
+        'NullableField' => 'Varchar(111, ["nullifyEmpty" => false])',
+        'HasDefault' => 'Varchar(50, ["default" => "default value"])',
+        'HasDefaultOldSyntax' => 'Varchar(50, array("default" => "default value"))',
     ];
 }


### PR DESCRIPTION
> [!IMPORTANT]
> There are intentionally two commits. DO NOT SQUASH

1. first commit:
    - Don't obstruct options array
    - Make sure default values are passed to requireField
    - Fix options where necessary
1. second commit:
    - Deprecate `DBField->arrayValue` and the corresponding getter and setter, which have never been used from what I can tell since their introduction in framework 2.3
    - Deprecate `DBEnum->default` and the corresponding getter and setter, which are redundant to `getDefaultValue()` and `setDefaultValue()`.

Doing this in a minor because _theoretically_ someone could be using the `setArrayValue()` functionality to do something that somehow breaks stuff when being passed in through options. That's extremely unlikely, especially since `arrayValue` is never used anywhere in core, nor has it even been used since its introduction in framework 2.3 from what I can tell, not even in the postgresql, mssql, or sqlite modules... but better safe than sorry.

Note that the docs don't specify anything about default values for date,time,year etc fields - it explicitly refers to ints (and I'll update that to include float/double/etc), and strings. For this reason (and because the utility would be minimal) I haven't done anything about pushing default values through for date, datetime, year, etc.

> [!NOTE]
> It's probably a good idea to read the changelog details before merging this as it changes some things that might not be obvious just from looking at the code changes.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11873