### PR TITLE
Add functionality needed by version-admin PR

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -176,7 +176,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             && ClassInfo::hasMethod($singleton, 'searchableFields')
         ) {
             // note: searchableFields() will return summary_fields if there are no searchable_fields on the model
-            $searchableFields = array_keys($singleton->searchableFields());
+            $searchableFields = array_keys($this->getSearchableFields($gridField, $singleton));
             $summaryFields = array_keys($singleton->summaryFields());
             sort($searchableFields);
             sort($summaryFields);
@@ -192,7 +192,10 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             }
         } else {
             // Allows non-DataObject classes to be used with this component
-            $columns = $gridField->getColumns();
+            $columns = array_merge(
+                $gridField->getColumns(),
+                array_keys($this->getSearchableFields($gridField, $singleton))
+            );
             foreach ($columns as $columnField) {
                 $metadata = $gridField->getColumnMetadata($columnField);
                 $title = $metadata['title'];
@@ -203,6 +206,19 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             }
         }
         return false;
+    }
+
+    private function getSearchableFields(GridField $gridField, object $singleton): array
+    {
+        try {
+            return $this->getSearchContext($gridField)->getSearchFieldsSpec($singleton);
+        } catch (LogicException) {
+            // Fall back to just searchable fields on the record itself.
+            if (ClassInfo::hasMethod($singleton, 'searchableFields')) {
+                return $singleton->searchableFields();
+            }
+            return [];
+        }
     }
 
     /**

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -16,7 +16,6 @@ use SilverStripe\Core\Validation\ValidationInterface;
 use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\Deprecation;
-use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\FormScaffolder;
@@ -2496,20 +2495,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
 
             // If we're using a WithinRangeFilter, split the field into two separate fields (from and to)
             if (is_a($spec['filter'] ?? '', WithinRangeFilter::class, true)) {
-                $fieldFrom = $field;
-                $fieldTo = clone $field;
-                $originalTitle = $field->Title();
-                $originalName = $field->getName();
-
-                $fieldFrom->setName($originalName . '_SearchFrom');
-                $fieldFrom->setTitle(_t(__CLASS__ . '.FILTER_WITHINRANGE_FROM', 'From'));
-                $fieldTo->setName($originalName . '_SearchTo');
-                $fieldTo->setTitle(_t(__CLASS__ . '.FILTER_WITHINRANGE_TO', 'To'));
-
-                $field = FieldGroup::create(
-                    $originalTitle,
-                    [$fieldFrom, $fieldTo]
-                )->setName($originalName)->addExtraClass('fieldgroup--fill-width');
+                $field = WithinRangeFilter::convertToRangeField($field);
             }
 
             $fields->push($field);

--- a/src/ORM/Filters/WithinRangeFilter.php
+++ b/src/ORM/Filters/WithinRangeFilter.php
@@ -2,6 +2,9 @@
 
 namespace SilverStripe\ORM\Filters;
 
+use SilverStripe\Forms\FieldGroup;
+use SilverStripe\Forms\FormField;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 
 class WithinRangeFilter extends SearchFilter
@@ -51,5 +54,26 @@ class WithinRangeFilter extends SearchFilter
                 $this->max
             ]
         ]);
+    }
+
+    /**
+     * Take a single form field and turn it into seaprate "from" and "to" fields in a group.
+     */
+    public static function convertToRangeField(FormField $originalField): FormField
+    {
+        $fieldFrom = $originalField;
+        $fieldTo = clone $originalField;
+        $originalTitle = $originalField->Title();
+        $originalName = $originalField->getName();
+
+        $fieldFrom->setName($originalName . '_SearchFrom');
+        $fieldFrom->setTitle(_t(DataObject::class . '.FILTER_WITHINRANGE_FROM', 'From'));
+        $fieldTo->setName($originalName . '_SearchTo');
+        $fieldTo->setTitle(_t(DataObject::class . '.FILTER_WITHINRANGE_TO', 'To'));
+
+        return FieldGroup::create(
+            $originalTitle,
+            [$fieldFrom, $fieldTo]
+        )->setName($originalName)->addExtraClass('fieldgroup--fill-width');
     }
 }

--- a/src/ORM/Search/BasicSearchContext.php
+++ b/src/ORM/Search/BasicSearchContext.php
@@ -124,13 +124,12 @@ class BasicSearchContext extends SearchContext
     private function getCanGeneralSearch(string $fieldName): bool
     {
         $singleton = singleton($this->modelClass);
+        $fields = $this->getSearchFieldsSpec($singleton);
 
         // Allowed if we're dealing with arbitrary data.
-        if (!ClassInfo::hasMethod($singleton, 'searchableFields')) {
+        if (empty($fields) && !ClassInfo::hasMethod($singleton, 'searchableFields')) {
             return true;
         }
-
-        $fields = $singleton->searchableFields();
 
         // Not allowed if the field isn't searchable.
         if (!isset($fields[$fieldName])) {

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -90,6 +90,12 @@ class SearchContext
     protected $withinRangeFieldsChecked = [];
 
     /**
+     * Specifications for searchable fields to add to the specifications returned from
+     * searchableFields() on the model.
+     */
+    private array $additionalFieldSpecs = [];
+
+    /**
      * A key value pair of values that should be searched for.
      * The keys should match the field names specified in {@link SearchContext::$fields}.
      * Usually these values come from a submitted searchform
@@ -117,18 +123,17 @@ class SearchContext
      */
     public function getSearchFields()
     {
-        if ($this->fields?->exists()) {
-            return $this->fields;
+        if (!$this->fields->exists()) {
+            $singleton = singleton($this->modelClass);
+            if (!$singleton->hasMethod('scaffoldSearchFields')) {
+                throw new LogicException(
+                    'Cannot dynamically determine search fields. Pass the fields to setFields()'
+                    . " or implement a scaffoldSearchFields() method on {$this->modelClass}"
+                );
+            }
+            $this->fields = $singleton->scaffoldSearchFields();
         }
-
-        $singleton = singleton($this->modelClass);
-        if (!$singleton->hasMethod('scaffoldSearchFields')) {
-            throw new LogicException(
-                'Cannot dynamically determine search fields. Pass the fields to setFields()'
-                . " or implement a scaffoldSearchFields() method on {$this->modelClass}"
-            );
-        }
-        return $singleton->scaffoldSearchFields();
+        return $this->fields;
     }
 
     protected function applyBaseTableFields()
@@ -175,7 +180,7 @@ class SearchContext
         $this->withinRangeFieldsChecked = [];
         /** @var DataObject $modelObj */
         $modelObj = Injector::inst()->create($this->modelClass);
-        $searchableFields = $modelObj->searchableFields();
+        $searchableFields = $this->getSearchFieldsSpec($modelObj);
         foreach ($this->searchParams as $searchField => $searchPhrase) {
             $searchField = str_replace('__', '.', $searchField ?? '');
             if ($searchField !== '' && $searchField === $modelObj->getGeneralSearchFieldName()) {
@@ -512,6 +517,47 @@ class SearchContext
     public function getSearchParams()
     {
         return $this->searchParams;
+    }
+
+    /**
+     * Get the specification for searchable fields, e.g. which fields can be used in general search.
+     * This is a combination of searchableFields() (where applicable) and getAdditionalFieldSpecs().
+     */
+    public function getSearchFieldsSpec(?object $modelObject): array
+    {
+        if (!$modelObject) {
+            $modelObject = Injector::inst()->create($this->modelClass);
+        }
+        if (!ClassInfo::hasMethod($modelObject, 'searchableFields')) {
+            return $this->getAdditionalFieldSpecs();
+        }
+        return array_merge($modelObject->searchableFields(), $this->getAdditionalFieldSpecs());
+    }
+
+    /**
+     * Get the additional field specifications that are applied on top of any searchableFields().
+     */
+    public function getAdditionalFieldSpecs(): array
+    {
+        return $this->additionalFieldSpecs;
+    }
+
+    /**
+     * Add field specifications to be applied on top of any searchableFields().
+     */
+    public function addAdditionalFieldSpecs(array $specs): static
+    {
+        $this->additionalFieldSpecs = array_merge($this->additionalFieldSpecs, $specs);
+        return $this;
+    }
+
+    /**
+     * Set field specifications to be applied on top of any searchableFields().
+     */
+    public function setAdditionalFieldSpecs(array $specs): static
+    {
+        $this->additionalFieldSpecs = $specs;
+        return $this;
     }
 
     public function getModelClass(): string

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forms\Tests\GridField;
 
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use ReflectionProperty;
 use SilverStripe\Control\HTTPRequest;
@@ -14,6 +15,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
+use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Cheerleader;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\CheerleaderHat;
@@ -197,6 +199,44 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $component = $gridField->getConfig()->getComponentByType(GridFieldFilterHeader::class);
 
         $this->assertFalse($component->canFilterAnyColumns($gridField));
+    }
+
+    public static function provideCanFilterAnyColumnsOnlyAdditional(): array
+    {
+        return [
+            [
+                'dataClass' => ArrayData::class,
+            ],
+            [
+                'dataClass' => Team::class,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideCanFilterAnyColumnsOnlyAdditional')]
+    public function testCanFilterAnyColumnsOnlyAdditional(string $dataClass): void
+    {
+        $config = GridFieldConfig::create()->addComponents([
+            $filter = new GridFieldFilterHeader(),
+            $columnData = new GridFieldDataColumns(),
+        ]);
+
+        if ($dataClass === ArrayData::class) {
+            $list = new ArrayList([
+                new ArrayData(['Title' => 'Boogie']),
+            ]);
+            $searchContext = new BasicSearchContext(ArrayData::class);
+            $columnData->setDisplayFields(['Title' => 'Title']);
+        } else {
+            $list = new DataList($dataClass);
+            $searchContext = singleton($dataClass)->getDefaultSearchContext();
+        }
+
+        $filter->setSearchContext($searchContext);
+        $searchContext->addAdditionalFieldSpecs(['Title' => []]);
+        $gridField = new GridField('testfield', 'testfield', $list, $config);
+
+        $this->assertTrue($filter->canFilterAnyColumns($gridField));
     }
 
     public function testRenderHeadersNonDataObject()

--- a/tests/php/ORM/Search/BasicSearchContextTest.php
+++ b/tests/php/ORM/Search/BasicSearchContextTest.php
@@ -342,6 +342,23 @@ class BasicSearchContextTest extends SapphireTest
         $this->assertCount(0, $results);
     }
 
+    public function testAdditionalFieldSpecs(): void
+    {
+        $general1 = $this->objFromFixture(SearchContextTest\GeneralSearch::class, 'general1');
+        $list = new ArrayList();
+        $list->merge(SearchContextTest\GeneralSearch::get());
+        $generalField = BasicSearchContext::config()->get('general_search_field_name');
+        $context = new BasicSearchContext(SearchContextTest\GeneralSearch::class);
+        $context->addAdditionalFieldSpecs([
+            'ExcludeThisField' => [
+                'general' => true,
+            ],
+        ]);
+        // Overriding the field spec above should let us find results using this field
+        $results = $context->getQuery([$generalField => $general1->ExcludeThisField], existingQuery: $list);
+        $this->assertNotEmpty($general1->ExcludeThisField);
+        $this->assertCount(2, $results);
+    }
 
     #[DataProviderExternal(SearchContextTest::class, 'provideQueryWithinRangeFilter')]
     public function testQueryWithinRangeFilter(array $params, array $expectedFixtureNames): void

--- a/tests/php/ORM/Search/SearchContextTest.php
+++ b/tests/php/ORM/Search/SearchContextTest.php
@@ -589,6 +589,41 @@ class SearchContextTest extends SapphireTest
         $results = $context->getResults([$generalField => 'arbitrary']);
         $this->assertCount(1, $results);
         $this->assertEquals('General One', $results->first()->Name);
+
+        // Matches nothing, because that field is excluded from general search
+        $results = $context->getResults([$generalField => 'excluded']);
+        $this->assertCount(0, $results);
+
+        // Matches against MatchAny1 or MatchAny2 field via MatchAny
+        $results = $context->getResults([$generalField => 'first']);
+        $this->assertCount(1, $results);
+        $results = $context->getResults([$generalField => 'second']);
+        $this->assertCount(1, $results);
+    }
+
+    public function testAdditionalFieldSpecs(): void
+    {
+        $general1 = $this->objFromFixture(SearchContextTest\GeneralSearch::class, 'general1');
+        $generalField = $general1->getGeneralSearchFieldName();
+        $context = $general1->getDefaultSearchContext();
+        $context->addAdditionalFieldSpecs([
+            'ExcludeThisField' => [
+                'general' => true,
+            ],
+            'MatchAny' => [
+                'match_any' => [
+                    'MatchAny1',
+                ],
+            ],
+        ]);
+
+        // Compare with testGeneralSearch
+        $results = $context->getResults([$generalField => 'excluded']);
+        $this->assertCount(2, $results);
+        $results = $context->getResults([$generalField => 'first']);
+        $this->assertCount(1, $results);
+        $results = $context->getResults([$generalField => 'second']);
+        $this->assertCount(0, $results);
     }
 
     public function testSpecificSearchFields()


### PR DESCRIPTION
> [!IMPORTANT]
> Multiple commits, DO NOT SQUASH

1. Moves functionality that splits one formfield into two for range filtering so it can be reused in https://github.com/silverstripe/silverstripe-versioned-admin/pull/431
2. Add ability to merge additional searchable_fields spec into the search context for use in that same PR.

## Issue

- https://github.com/silverstripe/silverstripe-versioned-admin/issues/228