### PR TITLE
FIX Clone GridState when cloning a GridField

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -1363,6 +1363,9 @@ class GridField extends FormField
     public function __clone(): void
     {
         $this->config = clone $this->config;
+        if ($this->state !== null) {
+            $this->state = clone $this->state;
+        }
     }
 
     /**

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -699,7 +699,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
         if ($position === 0 && $currentPage > 1) {
             $page = $currentPage - 1;
-        } elseif ($hasMorePages && $position >= $itemsPerPage + 1) {
+        } elseif ($hasMorePages && $position >= $itemsPerPage) {
             $page = $currentPage + 1;
         }
         $state->GridFieldPaginator->currentPage = (int)$page;

--- a/src/Forms/GridField/GridState.php
+++ b/src/Forms/GridField/GridState.php
@@ -131,4 +131,11 @@ class GridState extends HiddenField
     {
         return $this->getValue();
     }
+
+    public function __clone(): void
+    {
+        if ($this->data !== null) {
+            $this->data = clone $this->data;
+        }
+    }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/463

Fixes https://github.com/silverstripe/silverstripe-admin/actions/runs/19017583561/job/54307725239#step:12:971

[Kitchen sink CI](https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/19055252822)

This isn't really fixing a regression, it's fixing a bug that was highlighted after [this gridfield pagination PR](https://github.com/silverstripe/silverstripe-framework/pull/11892) was merged

The core issue is that the GridState is not cloned when cloning a GridField, so we were relying on buggy behaviour before

The lack of proper cloning occurs [here](https://github.com/silverstripe/silverstripe-framework/blob/6/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php#L722) 
