### PR TITLE
Changes required for the dependent dropdown field

### DIFF
--- a/src/Forms/ChildFieldManager.php
+++ b/src/Forms/ChildFieldManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\Forms;
+
+/**
+ * Interface that allows non-CompositeField implementations to surface their child fields
+ * for handling requests and getting/setting data.
+ */
+interface ChildFieldManager
+{
+    /**
+     * Returns true if this field manages a child field with the given name.
+     *
+     * If this form field manages fields which may handle actions, and this is not a subclass of
+     * CompositeField, this allows FormRequestHandler to find child fields to handle requests.
+     *
+     * If this method returns true the field must be accessible via getManagedFieldByName()
+     * and be returned in getManagedFields().
+     */
+    public function isManagedField(string $fieldName): bool;
+
+    /**
+     * Returns a named field which is managed by this parent field.
+     */
+    public function getManagedFieldByName(string $fieldName): ?FormField;
+
+    /**
+     * Returns a flat iterable of all fields managed by this parent field.
+     * @return iterable<FormField>
+     */
+    public function getManagedFields(): iterable;
+}

--- a/src/Forms/CompositeField.php
+++ b/src/Forms/CompositeField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms;
 
+use LogicException;
 use SilverStripe\Core\Validation\FieldValidation\CompositeFieldValidator;
 use SilverStripe\Dev\Debug;
 
@@ -58,6 +59,9 @@ class CompositeField extends FormField
 
     public function __construct($children = null)
     {
+        if ($this instanceof ChildFieldManager) {
+            throw new LogicException('CompositeField must not implement ChildFieldManager');
+        }
         // Normalise $children to a FieldList
         if (!$children instanceof FieldList) {
             if (!is_array($children)) {

--- a/src/Forms/CompositeField.php
+++ b/src/Forms/CompositeField.php
@@ -15,6 +15,8 @@ use SilverStripe\Dev\Debug;
  */
 class CompositeField extends FormField
 {
+    use FieldSetTrait;
+
     private static array $field_validators = [
         CompositeFieldValidator::class,
     ];
@@ -40,18 +42,6 @@ class CompositeField extends FormField
      * count of your $children.
      */
     protected $columnCount = null;
-
-    /**
-     * @var string custom HTML tag to render with, e.g. to produce a <fieldset>.
-     */
-    protected $tag = 'div';
-
-    /**
-     * @var string Optional description for this set of fields.
-     * If the {@link $tag} property is set to use a 'fieldset', this will be
-     * rendered as a <legend> tag, otherwise its a 'title' attribute.
-     */
-    protected $legend;
 
     protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_STRUCTURAL;
 
@@ -162,43 +152,6 @@ class CompositeField extends FormField
         $this->children = $children;
         $children->setContainerField($this);
         return $this;
-    }
-
-    /**
-     * @param string $tag
-     * @return $this
-     */
-    public function setTag($tag)
-    {
-        $this->tag = $tag;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTag()
-    {
-        return $this->tag;
-    }
-
-    /**
-     * @param string $legend
-     * @return $this
-     */
-    public function setLegend($legend)
-    {
-        $this->legend = $legend;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLegend()
-    {
-        return $this->legend;
     }
 
     public function extraClass()

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -90,8 +90,11 @@ class FieldList extends ArrayList
     }
 
     /**
-     * Return a sequential set of all fields that have data.  This excludes wrapper composite fields
+     * Return a sequential set of all fields that have data. This excludes wrapper composite fields
      * as well as heading / help text fields.
+     *
+     * Excludes fields that are exclusively managed through a {@see ChildFieldManager}. If you want to
+     * set or get values, you may want to use {@see FieldList::getAllDataFields()} instead.
      *
      * @return array<FormField>
      */
@@ -115,22 +118,65 @@ class FieldList extends ArrayList
     }
 
     /**
+     * Return all fields that have data including fields that are exclusively managed through a {@see ChildFieldManager}.
+     *
+     * Note that this method is intended only for getting and setting data for these fields. It should not be
+     * used for general use cases such as replacing/removing/reordering etc. Most of the time the ChildFieldManager should be
+     * left to manage the form fields directly.
+     * Use {@see FieldList::dataFields()} for most cases.
+     *
+     * @return array<FormField>
+     */
+    public function getAllDataFields(): array
+    {
+        $fields = $this->dataFields();
+        // Recursively add managed fields.
+        // Note that we explicitly don't cache these fields because the field manager
+        // is allowed to swap out field implementations for the same named field
+        // inbetween calls to this method.
+        $addDataField = function (FormField $field) use (&$fields, &$addDataField) {
+            if (!is_a($field, ChildFieldManager::class)) {
+                return;
+            }
+            foreach ($field->getManagedFields() as $managedField) {
+                $addDataField($managedField);
+                if (!$managedField->hasData()) {
+                    return;
+                }
+                $name = $managedField->getName();
+                if (isset($fields[$name])) {
+                    $this->fieldNameError($managedField, 'getAllDataFields');
+                }
+                $fields[$name] = $managedField;
+            }
+        };
+        $this->recursiveWalk($addDataField);
+        return $fields;
+    }
+
+    /**
      * @return array<FormField>
      */
     public function saveableFields(): array
     {
         if (empty($this->sequentialSaveableSet)) {
             $fields = [];
-            $this->recursiveWalk(function (FormField $field) use (&$fields) {
+            $addSaveableField = function (FormField $field) use (&$fields, &$addSaveableField) {
+                if ($field instanceof ChildFieldManager) {
+                    foreach ($field->getManagedFields() as $managedField) {
+                        $addSaveableField($managedField);
+                    }
+                }
                 if (!$field->canSubmitValue()) {
                     return;
                 }
                 $name = $field->getName();
                 if (isset($fields[$name])) {
-                    $this->fieldNameError($field, __FUNCTION__);
+                    $this->fieldNameError($field, 'saveableFields');
                 }
                 $fields[$name] = $field;
-            });
+            };
+            $this->recursiveWalk($addSaveableField);
             $this->sequentialSaveableSet = $fields;
         }
         return $this->sequentialSaveableSet;
@@ -612,7 +658,7 @@ class FieldList extends ArrayList
      */
     public function setValues(array $data): static
     {
-        foreach ($this->dataFields() as $field) {
+        foreach ($this->getAllDataFields() as $field) {
             $fieldName = $field->getName();
             if (isset($data[$fieldName])) {
                 $field->setValue($data[$fieldName]);

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms;
 
 use InvalidArgumentException;
 use RuntimeException;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Model\List\ArrayList;
@@ -93,13 +94,32 @@ class FieldList extends ArrayList
      * Return a sequential set of all fields that have data. This excludes wrapper composite fields
      * as well as heading / help text fields.
      *
-     * Excludes fields that are exclusively managed through a {@see ChildFieldManager}. If you want to
-     * set or get values, you may want to use {@see FieldList::getAllDataFields()} instead.
+     * Excludes fields that are exclusively managed through a {@see ChildFieldManager}.
      *
      * @return array<FormField>
+     * @deprecated 6.2.0 use FieldList::getDataFields() instead.
      */
     public function dataFields(): array
     {
+        Deprecation::notice('6.2.0', 'Use FieldList::getDataFields() instead.');
+        return $this->getDataFields();
+    }
+
+    /**
+     * Return a flat array of all fields that have data, optionally including fields that are exclusively managed
+     * through a {@see ChildFieldManager}.
+     * This excludes wrapper composite fields as well as heading / help text fields.
+     *
+     * @param bool $includeManagedFields whether to include fields managed through a {@see ChildFieldManager}.
+     * Passing true to this parameter is intended only for getting and setting data for these fields. It should not be
+     * used for general use cases such as replacing/removing/reordering etc. Most of the time the ChildFieldManager should be
+     * left to manage the form fields directly.
+     *
+     * @return array<FormField>
+     */
+    public function getDataFields(bool $includeManagedFields = false): array
+    {
+        // Get and cache non-managed data fields.
         if (empty($this->sequentialSet)) {
             $fields = [];
             $this->recursiveWalk(function (FormField $field) use (&$fields) {
@@ -114,27 +134,15 @@ class FieldList extends ArrayList
             });
             $this->sequentialSet = $fields;
         }
-        return $this->sequentialSet;
-    }
-
-    /**
-     * Return all fields that have data including fields that are exclusively managed through a {@see ChildFieldManager}.
-     *
-     * Note that this method is intended only for getting and setting data for these fields. It should not be
-     * used for general use cases such as replacing/removing/reordering etc. Most of the time the ChildFieldManager should be
-     * left to manage the form fields directly.
-     * Use {@see FieldList::dataFields()} for most cases.
-     *
-     * @return array<FormField>
-     */
-    public function getAllDataFields(): array
-    {
-        $fields = $this->dataFields();
+        $dataFields = $this->sequentialSet;
+        if (!$includeManagedFields) {
+            return $dataFields;
+        }
         // Recursively add managed fields.
         // Note that we explicitly don't cache these fields because the field manager
         // is allowed to swap out field implementations for the same named field
         // inbetween calls to this method.
-        $addDataField = function (FormField $field) use (&$fields, &$addDataField) {
+        $addDataField = function (FormField $field) use (&$dataFields, &$addDataField) {
             if (!is_a($field, ChildFieldManager::class)) {
                 return;
             }
@@ -144,14 +152,14 @@ class FieldList extends ArrayList
                     return;
                 }
                 $name = $managedField->getName();
-                if (isset($fields[$name])) {
-                    $this->fieldNameError($managedField, 'getAllDataFields');
+                if (isset($dataFields[$name])) {
+                    $this->fieldNameError($managedField, 'getDataFields');
                 }
-                $fields[$name] = $managedField;
+                $dataFields[$name] = $managedField;
             }
         };
         $this->recursiveWalk($addDataField);
-        return $fields;
+        return $dataFields;
     }
 
     /**
@@ -183,11 +191,11 @@ class FieldList extends ArrayList
     }
 
     /**
-     * Return array of all field names
+     * Return array of all data field names
      */
     public function dataFieldNames(): array
     {
-        return array_keys($this->dataFields() ?? []);
+        return array_keys($this->getDataFields(true) ?? []);
     }
 
     /**
@@ -524,7 +532,7 @@ class FieldList extends ArrayList
      */
     public function dataFieldByName(string $name): ?FormField
     {
-        if ($dataFields = $this->dataFields()) {
+        if ($dataFields = $this->getDataFields()) {
             foreach ($dataFields as $child) {
                 if (trim($name ?? '') == trim($child->getName() ?? '') || $name == $child->id) {
                     return $child;
@@ -658,7 +666,7 @@ class FieldList extends ArrayList
      */
     public function setValues(array $data): static
     {
-        foreach ($this->getAllDataFields() as $field) {
+        foreach ($this->getDataFields(true) as $field) {
             $fieldName = $field->getName();
             if (isset($data[$fieldName])) {
                 $field->setValue($data[$fieldName]);
@@ -675,7 +683,7 @@ class FieldList extends ArrayList
     public function HiddenFields(): FieldList
     {
         $hiddenFields = new FieldList();
-        $dataFields = $this->dataFields();
+        $dataFields = $this->getDataFields();
 
         if ($dataFields) {
             foreach ($dataFields as $field) {
@@ -788,7 +796,7 @@ class FieldList extends ArrayList
 
         // Build a map of fields indexed by their name.  This will make the 2nd step much easier.
         $fieldMap = [];
-        foreach ($this->dataFields() as $field) {
+        foreach ($this->getDataFields() as $field) {
             $fieldMap[$field->getName()] = $field;
         }
 
@@ -826,7 +834,7 @@ class FieldList extends ArrayList
         }
 
         $i = 0;
-        foreach ($this->dataFields() as $child) {
+        foreach ($this->getDataFields() as $child) {
             if ($child->getName() == $field) {
                 return $i;
             }

--- a/src/Forms/FieldSetTrait.php
+++ b/src/Forms/FieldSetTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SilverStripe\Forms;
+
+/**
+ * Trait that provides methods and properties necessary for fields that can be rendered as a fieldset or as a div.
+ */
+trait FieldSetTrait
+{
+    /**
+     * @var string custom HTML tag to render with, e.g. to produce a `<fieldset>`.
+     */
+    protected $tag = 'div';
+
+    /**
+     * @var string Optional description for this set of fields.
+     * If the {@link $tag} property is set to use a 'fieldset', this will be
+     * rendered as a `<legend>` tag, otherwise its a 'title' attribute.
+     */
+    protected $legend;
+
+    /**
+     * @param string $tag
+     * @return $this
+     */
+    public function setTag($tag)
+    {
+        $this->tag = $tag;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->tag;
+    }
+
+    /**
+     * @param string $legend
+     * @return $this
+     */
+    public function setLegend($legend)
+    {
+        $this->legend = $legend;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLegend()
+    {
+        return $this->legend;
+    }
+}

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1022,7 +1022,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
             return $this->encType;
         }
 
-        if ($fields = $this->fields->dataFields()) {
+        if ($fields = $this->fields->getAllDataFields()) {
             foreach ($fields as $field) {
                 if ($field instanceof FileField) {
                     return Form::ENC_TYPE_MULTIPART;
@@ -1370,7 +1370,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
      * It will call $object->MyField to get the value of MyField.
      * If you passed an array, it will call $object[MyField].
      * Doesn't save into dataless FormFields ({@link DatalessField}),
-     * as determined by {@link FieldList->dataFields()}.
+     * as determined by {@link FieldList->getAllDataFields()}.
      *
      * By default, if a field isn't set (as determined by isset()),
      * its value will not be saved to the field, retaining
@@ -1432,7 +1432,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
         }
 
         // Don't include fields without data
-        $dataFields = $this->Fields()->dataFields();
+        $dataFields = $this->Fields()->getAllDataFields();
 
         if (!$dataFields) {
             return $this;
@@ -1594,7 +1594,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
      */
     public function getData()
     {
-        $dataFields = $this->fields->dataFields();
+        $dataFields = $this->fields->getAllDataFields();
         $data = [];
 
         if ($dataFields) {

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1022,7 +1022,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
             return $this->encType;
         }
 
-        if ($fields = $this->fields->getAllDataFields()) {
+        if ($fields = $this->fields->getDataFields(true)) {
             foreach ($fields as $field) {
                 if ($field instanceof FileField) {
                     return Form::ENC_TYPE_MULTIPART;
@@ -1370,7 +1370,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
      * It will call $object->MyField to get the value of MyField.
      * If you passed an array, it will call $object[MyField].
      * Doesn't save into dataless FormFields ({@link DatalessField}),
-     * as determined by {@link FieldList->getAllDataFields()}.
+     * as determined by {@link FieldList->getDataFields()}.
      *
      * By default, if a field isn't set (as determined by isset()),
      * its value will not be saved to the field, retaining
@@ -1432,7 +1432,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
         }
 
         // Don't include fields without data
-        $dataFields = $this->Fields()->getAllDataFields();
+        $dataFields = $this->Fields()->getDataFields(true);
 
         if (!$dataFields) {
             return $this;
@@ -1584,7 +1584,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
 
     /**
      * Get the submitted data from this form through
-     * {@link FieldList->dataFields()}, which filters out
+     * {@link FieldList->getDataFields()}, which filters out
      * any form-specific data like form-actions.
      * Calls {@link FormField->dataValue()} on each field,
      * which returns a value suitable for insertion into a record
@@ -1594,7 +1594,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
      */
     public function getData()
     {
-        $dataFields = $this->fields->getAllDataFields();
+        $dataFields = $this->fields->getDataFields(true);
         $data = [];
 
         if ($dataFields) {

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -92,6 +92,9 @@ class FormField extends RequestHandler implements FieldValidationInterface
     /** @see $schemaDataType */
     const SCHEMA_DATA_TYPE_STRUCTURAL = 'Structural';
 
+    /** @see $schemaDataType */
+    const SCHEMA_DATA_TYPE_STRUCTURAL_CUSTOM = 'StructuralCustom';
+
     /**
      * @var Form
      */
@@ -242,6 +245,10 @@ class FormField extends RequestHandler implements FieldValidationInterface
      *   - Structural: Represents a field that is NOT posted back. This may contain other fields,
      *     or simply be a block of stand-alone content. As with 'Custom',
      *     the component property is mandatory if this is assigned.
+     *   - StructuralCustom: Represents a field that is NOT posted back. This field must have the
+     *     capability of containing other fields - the child field schema will be passed in instead
+     *     of passing in the child components directly. The component property is mandatory if this
+     *     is assigned.
      *
      * Each value has an equivalent constant, e.g. {@link FormField::SCHEMA_DATA_TYPE_STRING}.
      *

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -428,14 +428,27 @@ class FormRequestHandler extends RequestHandler
      */
     public function handleField($request)
     {
-        $field = $this->form->Fields()->dataFieldByName($request->param('FieldName'));
+        $fieldName = $request->param('FieldName');
+        $fields = $this->form->Fields();
+        $field = $fields->dataFieldByName($fieldName);
 
-        if ($field) {
-            return $field;
-        } else {
-            // falling back to fieldByName, e.g. for getting tabs
-            return $this->form->Fields()->fieldByName($request->param('FieldName'));
+        if (!$field) {
+            // Falling back to non-data fields, e.g. tabs.
+            // Note we can't just use `fieldByName()` because that isn't recursive and we can't
+            // modify it to be recursive due to backwards compatibility concerns.
+            $fields->recursiveWalk(function (FormField $candidate) use ($fieldName, &$field) {
+                if ($candidate->getName() === $fieldName) {
+                    $field = $candidate;
+                }
+
+                // Handle field that is managed by a ChildFieldManager (whether it's a data field or not)
+                if (!$field && is_a($candidate, ChildFieldManager::class) && $candidate->isManagedField($fieldName)) {
+                    $field = $candidate->getManagedFieldByName($fieldName);
+                }
+            });
         }
+
+        return $field;
     }
 
     /**

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -486,8 +486,8 @@ class FormRequestHandler extends RequestHandler
      */
     protected function getAllActions()
     {
-        $fields = $this->form->Fields()->dataFields();
-        $actions = $this->form->Actions()->dataFields();
+        $fields = $this->form->Fields()->getDataFields(true);
+        $actions = $this->form->Actions()->getDataFields(true);
 
         $fieldsAndActions = array_merge($fields, $actions);
         $actions = array_filter($fieldsAndActions ?? [], function ($fieldOrAction) {

--- a/src/Forms/Schema/FormSchema.php
+++ b/src/Forms/Schema/FormSchema.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Core\Validation\ValidationResult;
 use LogicException;
+use SilverStripe\Forms\ChildFieldManager;
 
 /**
  * Represents a {@link Form} as structured data which allows a frontend library to render it.
@@ -207,10 +208,16 @@ class FormSchema
     {
         $states = [];
         foreach ($fields as $field) {
-            $states[] = $field->getSchemaState();
+            $fieldState = $field->getSchemaState();
+            $states[] = $fieldState;
 
             if ($field instanceof CompositeField) {
                 $subFields = $field->FieldList();
+                $states = array_merge($states, $this->getFieldStates($subFields));
+            }
+
+            if ($field instanceof ChildFieldManager) {
+                $subFields = $field->getManagedFields();
                 $states = array_merge($states, $this->getFieldStates($subFields));
             }
         }

--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -182,8 +182,8 @@ trait SearchableDropdownTrait
         if ($this->searchContext) {
             return $this->searchContext;
         }
-        if ($this->sourceList) {
-            $dataClass = $this->sourceList->dataClass();
+        if ($this->getSourceList()) {
+            $dataClass = $this->getSourceList()->dataClass();
             /** @var DataObject $obj */
             $obj = $dataClass::create();
             return $obj->getDefaultSearchContext();
@@ -265,7 +265,7 @@ trait SearchableDropdownTrait
      */
     public function getSource(): array
     {
-        return $this->getListMap($this->sourceList);
+        return $this->getListMap($this->getSourceList());
     }
 
     public function Field($properties = [])
@@ -284,6 +284,15 @@ trait SearchableDropdownTrait
         // docblock type is array|ArrayAccess i.e. does not allow DataList
         $this->sourceList = $source;
         return $this;
+    }
+
+    /**
+     * Get the underlying list that represents the source for this dropdown.
+     * To set, use setSource().
+     */
+    public function getSourceList(): ?DataList
+    {
+        return $this->sourceList;
     }
 
     /**
@@ -499,10 +508,10 @@ trait SearchableDropdownTrait
 
     private function getOptionsForSearchRequest(string $term): array
     {
-        if (!$this->sourceList) {
+        if (!$this->getSourceList()) {
             return [];
         }
-        $dataClass = $this->sourceList->dataClass();
+        $dataClass = $this->getSourceList()->dataClass();
         $labelField = $this->getLabelField();
         /** @var DataObject $obj */
         $obj = $dataClass::create();
@@ -530,14 +539,14 @@ trait SearchableDropdownTrait
     private function getOptionsForSchema(bool $onlySelected = false): ArrayList
     {
         $options = ArrayList::create();
-        if (!$this->sourceList) {
+        if (!$this->getSourceList()) {
             return $options;
         }
         $values = $this->getValueArray();
         if (empty($values)) {
             $selectedValuesList = ArrayList::create();
         } else {
-            $selectedValuesList = $this->sourceList->filterAny(['ID' => $values]);
+            $selectedValuesList = $this->getSourceList()->filterAny(['ID' => $values]);
         }
         // SearchableDropdownField will have the getHasEmptyDefault() method from SingleSelectField
         // Note that SingleSelectField::getSourceEmpty() will not be called for the react-select component
@@ -552,7 +561,7 @@ trait SearchableDropdownTrait
         if ($onlySelected) {
             $options = $this->updateOptionsForSchema($options, $selectedValuesList, $selectedValuesList);
         } else {
-            $options = $this->updateOptionsForSchema($options, $this->sourceList, $selectedValuesList);
+            $options = $this->updateOptionsForSchema($options, $this->getSourceList(), $selectedValuesList);
         }
         return $options;
     }
@@ -609,7 +618,7 @@ trait SearchableDropdownTrait
         // call to $this->getSource() which will load the entire DataList into memory which
         // causes issues with very large datasets and isn't needed when the field is read-only
         $field = call_user_func('SilverStripe\\Forms\\FormField::castedCopy', SearchableLookupField::class);
-        $field->setSource($this->sourceList);
+        $field->setSource($this->getSourceList());
         $field->setReadonly(true);
 
         return $field;
@@ -617,6 +626,6 @@ trait SearchableDropdownTrait
 
     protected function getSourceValues()
     {
-        return $this->sourceList->sort(null)->column('ID');
+        return $this->getSourceList()->sort(null)->column('ID');
     }
 }

--- a/src/Forms/Validation/RequiredFieldsValidator.php
+++ b/src/Forms/Validation/RequiredFieldsValidator.php
@@ -130,6 +130,11 @@ class RequiredFieldsValidator extends Validator
                 $fieldName = $fieldName->getName();
             } else {
                 $formField = $fields->dataFieldByName($fieldName);
+                if (!$formField) {
+                    // Maybe it's a managed field.
+                    $dataFields = $fields->getAllDataFields();
+                    $formField = $dataFields[$fieldName] ?? null;
+                }
             }
 
             // submitted data for file upload fields come back as an array

--- a/src/Forms/Validation/RequiredFieldsValidator.php
+++ b/src/Forms/Validation/RequiredFieldsValidator.php
@@ -132,7 +132,7 @@ class RequiredFieldsValidator extends Validator
                 $formField = $fields->dataFieldByName($fieldName);
                 if (!$formField) {
                     // Maybe it's a managed field.
-                    $dataFields = $fields->getAllDataFields();
+                    $dataFields = $fields->getDataFields(true);
                     $formField = $dataFields[$fieldName] ?? null;
                 }
             }

--- a/tests/php/Forms/FieldListTest.php
+++ b/tests/php/Forms/FieldListTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms\Tests;
 
 use stdClass;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\ConfirmedPasswordField;
@@ -373,30 +374,16 @@ class FieldListTest extends SapphireTest
         $this->assertNull($fields->dataFieldByName('ChildFieldManager'));
     }
 
-    public function testDataFields()
+    public static function provideDataFields(): array
     {
-        $fields = new FieldList([
-            $field1 = new TextField('Name', 'Your name'),
-            $field2 = new TextField('Name[Field]', 'Your name'),
-            new CompositeField([
-                $field3 = new TextField('Field3', 'Your name'),
-                new ChildFieldManagerField([
-                    new TextField('Field4'),
-                ]),
-            ]),
-        ]);
-
-        $expected = [
-            'Name' => $field1,
-            'Name[Field]' => $field2,
-            'Field3' => $field3,
+        return [
+            [false],
+            [true],
         ];
-
-        $dataFields = $fields->dataFields();
-        $this->assertSame($expected, $dataFields);
     }
 
-    public function testGetAllDataFields()
+    #[DataProvider('provideDataFields')]
+    public function testDataFields(bool $includeManagedFields)
     {
         $fields = new FieldList([
             $field1 = new TextField('Name', 'Your name'),
@@ -413,10 +400,12 @@ class FieldListTest extends SapphireTest
             'Name' => $field1,
             'Name[Field]' => $field2,
             'Field3' => $field3,
-            'Field4' => $field4,
         ];
+        if ($includeManagedFields) {
+            $expected['Field4'] = $field4;
+        }
 
-        $dataFields = $fields->getAllDataFields();
+        $dataFields = $fields->getDataFields($includeManagedFields);
         $this->assertSame($expected, $dataFields);
     }
 
@@ -732,7 +721,7 @@ class FieldListTest extends SapphireTest
         );
 
         $this->assertEquals(
-            array_keys($fields->dataFields() ?? []),
+            array_keys($fields->getDataFields() ?? []),
             [
             'A',
             'NewField1',

--- a/tests/php/Forms/FieldListTest.php
+++ b/tests/php/Forms/FieldListTest.php
@@ -20,6 +20,7 @@ use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\Tests\FormTest\ChildFieldManagerField;
 
 /**
  * Tests for FieldList
@@ -88,14 +89,17 @@ class FieldListTest extends SapphireTest
             new CompositeField(
                 $day = new TextField('Day'),
                 $month = new TextField('Month'),
-                $year = new TextField('Year')
+                $year = new TextField('Year'),
+                new ChildFieldManagerField([
+                    $managed = new TextField('Managed'),
+                ]),
             ),
         ];
         $fieldList = new FieldList($fields);
 
         array_pop($fields);
         array_pop($fields);
-        array_push($fields, $day, $month, $year);
+        array_push($fields, $day, $month, $year, $managed);
 
         $this->assertEquals($fields, array_values($fieldList->saveableFields() ?? []));
     }
@@ -351,12 +355,69 @@ class FieldListTest extends SapphireTest
 
     public function testDataFieldByName()
     {
-        $fields = new FieldList();
-        $fields->push($basic = new TextField('Name', 'Your name'));
-        $fields->push($brack = new TextField('Name[Field]', 'Your name'));
+        $fields = new FieldList([
+            $field1 = new TextField('Name', 'Your name'),
+            $field2 = new TextField('Name[Field]', 'Your name'),
+            new CompositeField([
+                $field3 = new TextField('Field3', 'Your name'),
+                new ChildFieldManagerField([
+                    new TextField('Field4'),
+                ]),
+            ]),
+        ]);
 
-        $this->assertEquals($basic, $fields->dataFieldByName('Name'));
-        $this->assertEquals($brack, $fields->dataFieldByName('Name[Field]'));
+        $this->assertEquals($field1, $fields->dataFieldByName('Name'));
+        $this->assertEquals($field2, $fields->dataFieldByName('Name[Field]'));
+        $this->assertEquals($field3, $fields->dataFieldByName('Field3'));
+        $this->assertNull($fields->dataFieldByName('Field4'));
+        $this->assertNull($fields->dataFieldByName('ChildFieldManager'));
+    }
+
+    public function testDataFields()
+    {
+        $fields = new FieldList([
+            $field1 = new TextField('Name', 'Your name'),
+            $field2 = new TextField('Name[Field]', 'Your name'),
+            new CompositeField([
+                $field3 = new TextField('Field3', 'Your name'),
+                new ChildFieldManagerField([
+                    new TextField('Field4'),
+                ]),
+            ]),
+        ]);
+
+        $expected = [
+            'Name' => $field1,
+            'Name[Field]' => $field2,
+            'Field3' => $field3,
+        ];
+
+        $dataFields = $fields->dataFields();
+        $this->assertSame($expected, $dataFields);
+    }
+
+    public function testGetAllDataFields()
+    {
+        $fields = new FieldList([
+            $field1 = new TextField('Name', 'Your name'),
+            $field2 = new TextField('Name[Field]', 'Your name'),
+            new CompositeField([
+                $field3 = new TextField('Field3', 'Your name'),
+                new ChildFieldManagerField([
+                    $field4 = new TextField('Field4'),
+                ]),
+            ]),
+        ]);
+
+        $expected = [
+            'Name' => $field1,
+            'Name[Field]' => $field2,
+            'Field3' => $field3,
+            'Field4' => $field4,
+        ];
+
+        $dataFields = $fields->getAllDataFields();
+        $this->assertSame($expected, $dataFields);
     }
 
     /**
@@ -1208,5 +1269,27 @@ class FieldListTest extends SapphireTest
 
         $fieldlist->setContainerField(null);
         $this->assertNull($fieldlist->getContainerField());
+    }
+
+    public function testSetValues(): void
+    {
+        $fields = new FieldList([
+            $field1 = new TextField('FieldOne'),
+            new CompositeField([
+                $field2 = new TextField('FieldTwo'),
+                new ChildFieldManagerField([
+                    $field3 = new TextField('FieldThree')
+                ]),
+            ])
+        ]);
+
+        $fields->setValues([
+            'FieldOne' => 'val1',
+            'FieldTwo' => 'val2',
+            'FieldThree' => 'val3',
+        ]);
+        $this->assertSame('val1', $field1->getValue());
+        $this->assertSame('val2', $field2->getValue());
+        $this->assertSame('val3', $field3->getValue());
     }
 }

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -633,6 +633,9 @@ class FormFieldTest extends SapphireTest
                 //
                 // Fields from other modules included in the kitchensink recipe
                 //
+                case \SilverStripe\Admin\Forms\DependentCompositeField::class:
+                    $args = ['Test', 'Test', [TextField::create('Test2')]];
+                    break;
                 case \SilverStripe\Blog\Admin\GridFieldFormAction::class:
                     $args = [GridField::create('GF'), 'Test', 'Test label', 'Test action name', []];
                     break;

--- a/tests/php/Forms/FormRequestHandlerTest.php
+++ b/tests/php/Forms/FormRequestHandlerTest.php
@@ -2,16 +2,19 @@
 
 namespace SilverStripe\Forms\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\FormRequestHandler;
 use SilverStripe\Forms\PasswordField;
 use SilverStripe\Forms\Tests\FormRequestHandlerTest\TestForm;
 use SilverStripe\Forms\Tests\FormRequestHandlerTest\TestFormRequestHandler;
+use SilverStripe\Forms\Tests\FormTest\ChildFieldManagerField;
 use SilverStripe\Forms\TextField;
 
 class FormRequestHandlerTest extends SapphireTest
@@ -46,5 +49,52 @@ class FormRequestHandlerTest extends SapphireTest
         $request->setSession(new Session([]));
         $response = $handler->httpSubmission($request);
         $this->assertFalse($response->isError());
+    }
+
+    public static function provideHandleField(): array
+    {
+        return [
+            [
+                'fieldToRequest' => 'FieldOne',
+            ],
+            [
+                'fieldToRequest' => 'FieldTwo',
+            ],
+            [
+                'fieldToRequest' => 'FieldThree',
+            ],
+            [
+                'fieldToRequest' => 'NonExistantField',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideHandleField')]
+    public function testHandleField(string $fieldToRequest): void
+    {
+        $expectedFields = [
+            'FieldOne' => new TextField('FieldOne'),
+            'FieldTwo' => new TextField('FieldTwo'),
+            'FieldThree' => new TextField('FieldThree'),
+        ];
+        $form = new TestForm(
+            Controller::curr(),
+            'Form',
+            new FieldList([
+                $expectedFields['FieldOne'],
+                new CompositeField([
+                    $expectedFields['FieldTwo'],
+                    new ChildFieldManagerField([
+                        $expectedFields['FieldThree'],
+                    ]),
+                ]),
+            ]),
+            new FieldList(new FormAction('mySubmitOnForm'))
+        );
+        $handler = new FormRequestHandler($form);
+        $request = new HTTPRequest('GET', '');
+        // Setting the param here mimics what happens during real request handling further up the chain
+        $request->setRouteParams(['FieldName' => $fieldToRequest]);
+        $this->assertSame($expectedFields[$fieldToRequest] ?? null, $handler->handleField($request));
     }
 }

--- a/tests/php/Forms/FormSchemaTest.php
+++ b/tests/php/Forms/FormSchemaTest.php
@@ -17,6 +17,8 @@ use SilverStripe\Forms\PopoverField;
 use SilverStripe\Forms\FormField;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\Tests\FormTest\ChildFieldManagerField;
 
 class FormSchemaTest extends SapphireTest
 {
@@ -207,6 +209,43 @@ class FormSchemaTest extends SapphireTest
 
         $this->assertIsArray($schema);
         $this->assertEquals($expected, $schema);
+    }
+
+    public function testGetNestedState(): void
+    {
+        $form = new Form(
+            null,
+            'TestForm',
+            new FieldList([
+                new TextField("Name", value: 'awawa'),
+                (new HiddenField("MyHiddenField", value: 'ooooh'))
+                    ->setMessage('Some fancy message'),
+                new ChildFieldManagerField([
+                    (new TextField('NestedField', value: 'I am nested!'))
+                        ->setMessage('This is a nested message.'),
+                ]),
+            ]),
+            new FieldList(
+                (new FormAction("save", "Save"))
+                    ->setIcon('save'),
+                (new FormAction("cancel", "Cancel"))
+                    ->setUseButtonTag(true),
+                new PopoverField(
+                    "More options",
+                    [
+                        new FormAction("publish", "Publish record"),
+                        new FormAction("archive", "Archive"),
+                    ]
+                )
+            )
+        );
+        $form->disableSecurityToken();
+        $formSchema = new FormSchema();
+        $expected = json_decode(file_get_contents(__DIR__ . '/FormSchemaTest/testGetNestedState.json') ?? '', true);
+        $state = $formSchema->getState($form);
+
+        $this->assertIsArray($state);
+        $this->assertEquals($expected, $state);
     }
 
     /**

--- a/tests/php/Forms/FormSchemaTest/testGetNestedState.json
+++ b/tests/php/Forms/FormSchemaTest/testGetNestedState.json
@@ -1,0 +1,76 @@
+{
+  "id": "Form_TestForm",
+  "fields": [
+    {
+      "name": "Name",
+      "id": "Form_TestForm_Name",
+      "value": "awawa",
+      "message": null,
+      "data": []
+    },
+    {
+      "name": "MyHiddenField",
+      "id": "Form_TestForm_MyHiddenField",
+      "value": "ooooh",
+      "message": {
+        "value": "Some fancy message",
+        "type": "error"
+      },
+      "data": []
+    },
+    {
+      "name": "ChildFieldManager",
+      "id": "Form_TestForm_ChildFieldManager",
+      "value": null,
+      "message": null,
+      "data": []
+    },
+    {
+      "name": "NestedField",
+      "id": "NestedField",
+      "value": "I am nested!",
+      "message": {
+        "value": "This is a nested message.",
+        "type": "error"
+      },
+      "data": []
+    },
+    {
+      "name": "action_save",
+      "id": "Form_TestForm_action_save",
+      "value": null,
+      "message": null,
+      "data": []
+    },
+    {
+      "name": "action_cancel",
+      "id": "Form_TestForm_action_cancel",
+      "value": null,
+      "message": null,
+      "data": []
+    },
+    {
+      "name": "Moreoptions",
+      "id": "Form_TestForm_Moreoptions",
+      "value": "",
+      "message": null,
+      "data": []
+    },
+    {
+      "name": "action_publish",
+      "id": "Form_TestForm_action_publish",
+      "value": null,
+      "message": null,
+      "data": []
+    },
+    {
+      "name": "action_archive",
+      "id": "Form_TestForm_action_archive",
+      "value": null,
+      "message": null,
+      "data": []
+    }
+  ],
+  "messages": [],
+  "notifyUnsavedChanges": false
+}

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -200,7 +200,7 @@ class FormTest extends FunctionalTest
         $this->assertEquals('val4', $fields->fieldByName('namespace[key3][key4]')->getValue());
         $this->assertEquals('val7', $fields->fieldByName('othernamespace[key5][key6][key7]')->getValue());
         $this->assertEquals('dot.field val', $fields->fieldByName('dot.field')->getValue());
-        $this->assertEquals('managed value', $fields->getAllDataFields()['managed']->getValue());
+        $this->assertEquals('managed value', $fields->getDataFields(true)['managed']->getValue());
     }
 
     public function testSubmitReadonlyFields()

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -43,6 +43,7 @@ use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\SudoModePasswordField;
 use SilverStripe\Security\SudoMode\SudoModeServiceInterface;
 use SilverStripe\Forms\ReadonlyField;
+use SilverStripe\Forms\Tests\FormTest\ChildFieldManagerField;
 use SilverStripe\Forms\Validation\CompositeValidator;
 use SilverStripe\Forms\Validation\RequiredFieldsValidator;
 
@@ -165,7 +166,8 @@ class FormTest extends FunctionalTest
                 new TextField('namespace[key2]'),
                 new TextField('namespace[key3][key4]'),
                 new TextField('othernamespace[key5][key6][key7]'),
-                new TextField('dot.field')
+                new TextField('dot.field'),
+                new ChildFieldManagerField([new TextField('managed')]),
             ),
             new FieldList()
         );
@@ -186,8 +188,8 @@ class FormTest extends FunctionalTest
                     ]
                 ]
             ],
-            'dot.field' => 'dot.field val'
-
+            'dot.field' => 'dot.field val',
+            'managed' => 'managed value',
         ];
 
         $form->loadDataFrom($requestData);
@@ -198,6 +200,7 @@ class FormTest extends FunctionalTest
         $this->assertEquals('val4', $fields->fieldByName('namespace[key3][key4]')->getValue());
         $this->assertEquals('val7', $fields->fieldByName('othernamespace[key5][key6][key7]')->getValue());
         $this->assertEquals('dot.field val', $fields->fieldByName('dot.field')->getValue());
+        $this->assertEquals('managed value', $fields->getAllDataFields()['managed']->getValue());
     }
 
     public function testSubmitReadonlyFields()
@@ -267,7 +270,8 @@ class FormTest extends FunctionalTest
                 new TextareaField('Biography'),
                 new DateField('Birthday'),
                 new NumericField('BirthdayYear'), // dynamic property
-                new TextField('FavouriteTeam.Name') // dot syntax
+                new TextField('FavouriteTeam.Name'), // dot syntax
+                new ChildFieldManagerField([new TextField('ExtraField')]),
             ),
             new FieldList()
         );
@@ -282,6 +286,7 @@ class FormTest extends FunctionalTest
                 'Birthday' => '1982-01-01',
                 'BirthdayYear' => '1982',
                 'FavouriteTeam.Name' => 'Team 1',
+                'ExtraField' => 'some additional value',
             ],
             'LoadDataFrom() loads simple fields and dynamic getters'
         );
@@ -296,6 +301,7 @@ class FormTest extends FunctionalTest
                 'Birthday' => null,
                 'BirthdayYear' => 0,
                 'FavouriteTeam.Name' => null,
+                'ExtraField' => null,
             ],
             'LoadNonBlankDataFrom() loads only fields with values, and doesnt overwrite existing values'
         );
@@ -839,12 +845,19 @@ class FormTest extends FunctionalTest
         $form->setEncType(Form::ENC_TYPE_MULTIPART);
         $this->assertEquals('multipart/form-data', $form->getEncType());
 
+        // New form - add a FileField
         $form = $this->getStubForm();
         $form->Fields()->push(new FileField('MyField'));
         $this->assertEquals('multipart/form-data', $form->getEncType());
 
+        // Validate explicit enc type overrides detection
         $form->setEncType(Form::ENC_TYPE_URLENCODED);
         $this->assertEquals('application/x-www-form-urlencoded', $form->getEncType());
+
+        // New form - add a FileField through a child field manager
+        $form = $this->getStubForm();
+        $form->Fields()->push(new ChildFieldManagerField([new FileField('MyField')]));
+        $this->assertEquals('multipart/form-data', $form->getEncType());
     }
 
     public function testAddExtraClass()

--- a/tests/php/Forms/FormTest.yml
+++ b/tests/php/Forms/FormTest.yml
@@ -8,6 +8,7 @@ SilverStripe\Forms\Tests\FormTest\Player:
     Name: Captain Details
     Birthday: 1982-01-01
     Biography: Bio 1
+    ExtraField: some additional value
     FavouriteTeam: =>SilverStripe\Forms\Tests\FormTest\Team.team1
     Teams: =>SilverStripe\Forms\Tests\FormTest\Team.team1
   captainNoDetails:

--- a/tests/php/Forms/FormTest/ChildFieldManagerField.php
+++ b/tests/php/Forms/FormTest/ChildFieldManagerField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\FormTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\ChildFieldManager;
+use SilverStripe\Forms\DatalessField;
+use SilverStripe\Forms\FormField;
+
+class ChildFieldManagerField extends DatalessField implements ChildFieldManager, TestOnly
+{
+    /**
+     * @var array<FormField>
+     */
+    private array $fields;
+
+    public function __construct(array $children)
+    {
+        $this->fields = $children;
+        return parent::__construct('ChildFieldManager');
+    }
+
+    public function isManagedField(string $fieldName): bool
+    {
+        return (bool) $this->getManagedFieldByName($fieldName);
+    }
+
+    public function getManagedFieldByName(string $fieldName): ?FormField
+    {
+        foreach ($this->fields as $field) {
+            if ($field->getName() === $fieldName) {
+                return $field;
+            }
+        }
+        return null;
+    }
+
+    public function getManagedFields(): iterable
+    {
+        return $this->fields;
+    }
+}

--- a/tests/php/Forms/FormTest/Player.php
+++ b/tests/php/Forms/FormTest/Player.php
@@ -13,7 +13,8 @@ class Player extends DataObject implements TestOnly
     private static $db = [
         'Name' => 'Varchar',
         'Biography' => 'Text',
-        'Birthday' => 'Date'
+        'Birthday' => 'Date',
+        'ExtraField' => 'Varchar',
     ];
 
     private static $belongs_many_many = [

--- a/tests/php/Forms/GridField/GridFieldLazyLoaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldLazyLoaderTest.php
@@ -225,7 +225,7 @@ class GridFieldLazyLoaderTest extends SapphireTest
     private function makeGridFieldReadonly(GridField $gridField)
     {
         $form = $gridField->getForm()->makeReadonly();
-        $fields = $form->Fields()->dataFields();
+        $fields = $form->Fields()->getDataFields();
         foreach ($fields as $field) {
             if ($field->getName() === 'testfield') {
                 return $field;

--- a/tests/php/Forms/RequiredFieldsValidatorTest.php
+++ b/tests/php/Forms/RequiredFieldsValidatorTest.php
@@ -9,8 +9,11 @@ use SilverStripe\Forms\SearchableDropdownField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Security\Group;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\Tests\FormTest\ChildFieldManagerField;
 
 class RequiredFieldsValidatorTest extends SapphireTest
 {
@@ -449,5 +452,51 @@ class RequiredFieldsValidatorTest extends SapphireTest
         RequiredFieldsValidator::config()->set('allow_whitespace_only', false);
         $result = $validator->validate($form);
         $this->assertEquals($expected, $result->isValid());
+    }
+
+    public function testValidation()
+    {
+        $form = new Form(fields: new FieldList([
+            new TextField('FieldOne'),
+            new CompositeField([
+                new HiddenField('FieldTwo'),
+                new ChildFieldManagerField([
+                    new TextField('FieldThree'),
+                ]),
+            ]),
+            new TextField('NotRequired'),
+        ]));
+        $validator = new RequiredFieldsValidator([
+            'FieldOne',
+            'FieldTwo',
+            'FieldThree'
+        ]);
+        $validator->setForm($form);
+        // Empty values and values missing entirely both fail validation.
+        $this->assertFalse($validator->php([
+            'FieldOne' => '',
+            'FieldTwo' => '',
+            'FieldThree' => '',
+        ]));
+        $this->assertFalse($validator->php([]));
+        // Any single missing field fails validation
+        $this->assertFalse($validator->php([
+            'FieldTwo' => '1',
+            'FieldThree' => '1',
+        ]));
+        $this->assertFalse($validator->php([
+            'FieldOne' => '1',
+            'FieldThree' => '1',
+        ]));
+        $this->assertFalse($validator->php([
+            'FieldOne' => '1',
+            'FieldTwo' => '1',
+        ]));
+        // non-empty value passes required field validation
+        $this->assertTrue($validator->php([
+            'FieldOne' => '1',
+            'FieldTwo' => '1',
+            'FieldThree' => '1',
+        ]));
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> There are multiple commits on purpose. DO NOT SQUASH

1. ENH Add schema type for special form fields
    Adds new `FormField::SCHEMA_DATA_TYPE_STRUCTURAL_CUSTOM` const.
    Not strictly necessary as we could just refer to it as a hardcoded string in the admin PR - but adding this here seems consistent with the other `SCHEMA_DATA_TYPE` consts (which one day maybe we'll turn into an enum)
1. ENH Allow fields to pass actions down to child-fields
    Adds a new interface and uses it in various places to allow the following behaviours for weirdly-nested fields (in a way that doesn't break that nesting e.g. intentionally doesn't find them for reordering or removing fields):
    - save data from the field into some record
    - fetch data from some record and set the value in the field
    - find the field when handling AJAX requests for form fields (e.g. `TreeDropdownField`'s `tree` action)
1. API Move fieldset-related API into new trait
    Not strictly necessary but allows for the new dependent composite field to be a div or a fieldset depending on the use case. Nice to have.
1. API Add getSourceList() method to searchable dropdowns
    Makes testing the admin PR easier and seems like sensible API to add, but I can work around it if there's any controversy about it.
1. API Deprecate FieldList::dataFields() and rename its replacement
    also update FormFieldTest to account for DependentCompositeField

Of these only 2 and 5 are strictly necessary - but the others make the implementation and tests a little cleaner.

I have also raised https://github.com/silverstripe/silverstripe-framework/issues/11927 to eventually use the new `ChildFieldManager` interface in `MoneyField`.

## Issue

- https://github.com/silverstripe/silverstripe-elemental/issues/445