### PR TITLE
FIX EagerLoading: Don't throw unknown column error when list is empty

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1169,6 +1169,10 @@ class DataList extends ModelData implements SS_List, Resettable
             $chainToDate = [];
             $polymorphicEncountered = false;
             foreach (explode('.', $relationChain) as $relationName) {
+                // Skip sub relations if no parent IDs are available
+                if (empty($parentIDs)) {
+                    break;
+                }
                 if ($polymorphicEncountered) {
                     $polymorphicRelation = $chainToDate[array_key_last($chainToDate)];
                     throw new InvalidArgumentException(

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -495,17 +495,15 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
 
     public function filter(...$args): static
     {
-        $filters = $this->normaliseFilterArgs($args, __FUNCTION__);
         $list = clone $this;
-        $list->rows = $this->getMatches($filters);
+        $list->rows = $this->getMatchesFromArgs($args, __FUNCTION__);
         return $list;
     }
 
     public function filterAny(...$args): static
     {
-        $filters = $this->normaliseFilterArgs($args, __FUNCTION__);
         $list = clone $this;
-        $list->rows = $this->getMatches($filters, true);
+        $list->rows = $this->getMatchesFromArgs($args, __FUNCTION__, true);
         return $list;
     }
 
@@ -527,8 +525,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
 
     public function exclude(...$args): static
     {
-        $filters = $this->normaliseFilterArgs($args, __FUNCTION__);
-        $toRemove = $this->getMatches($filters);
+        $toRemove = $this->getMatchesFromArgs($args, __FUNCTION__);
         $list = clone $this;
         foreach ($toRemove as $id => $row) {
             unset($list->rows[$id]);
@@ -543,8 +540,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
      */
     public function excludeAny(...$args): static
     {
-        $filters = $this->normaliseFilterArgs($args, __FUNCTION__);
-        $toRemove = $this->getMatches($filters, true);
+        $toRemove = $this->getMatchesFromArgs($args, __FUNCTION__, true);
         $list = clone $this;
         foreach ($toRemove as $id => $row) {
             unset($list->rows[$id]);
@@ -660,6 +656,17 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
             }
         }
         return $matches;
+    }
+
+    private function getMatchesFromArgs(array $args, string $function, bool $any = false): array
+    {
+        if (empty($this->rows)) {
+            return [];
+        }
+
+        $filters = $this->normaliseFilterArgs($args, $function);
+
+        return $this->getMatches($filters, $any);
     }
 
     /**

--- a/tests/php/ORM/DataListEagerLoadingTest.php
+++ b/tests/php/ORM/DataListEagerLoadingTest.php
@@ -861,9 +861,10 @@ class DataListEagerLoadingTest extends SapphireTest
     {
         EagerLoadObject::create(['Title' => 'test object'])->write();
         $dataList = EagerLoadObject::get()->eagerLoad($eagerLoadRelation);
+        $firstRelation = strtok($eagerLoadRelation, '.');
         $this->startCountingSelectQueries();
         foreach ($dataList as $record) {
-            $relation = $record->$eagerLoadRelation();
+            $relation = $record->$firstRelation();
             if ($relation instanceof SS_List) {
                 // The list should be an empty eagerloaded list
                 $this->assertInstanceOf(EagerLoadedList::class, $relation);
@@ -906,6 +907,30 @@ class DataListEagerLoadingTest extends SapphireTest
             ],
             'belongs_many_many' => [
                 'eagerLoadRelation' => 'BelongsManyManyEagerLoadObjects',
+                'expectedNumQueries' => 2,
+            ],
+            'has_one sub relation' => [
+                'eagerLoadRelation' => 'HasOneEagerLoadObject.HasOneSubEagerLoadObject',
+                'expectedNumQueries' => 1,
+            ],
+            'belongs_to sub relation' => [
+                'eagerLoadRelation' => 'BelongsToEagerLoadObject.BelongsToSubEagerLoadObject',
+                'expectedNumQueries' => 2,
+            ],
+            'has_many sub relation' => [
+                'eagerLoadRelation' => 'HasManyEagerLoadObjects.HasManySubEagerLoadObjects',
+                'expectedNumQueries' => 2,
+            ],
+            'many_many sub relation' => [
+                'eagerLoadRelation' => 'ManyManyEagerLoadObjects.ManyManySubEagerLoadObjects',
+                'expectedNumQueries' => 2,
+            ],
+            'many_many through sub relation' => [
+                'eagerLoadRelation' => 'ManyManyThroughEagerLoadObjects.ManyManyThroughSubEagerLoadObjects',
+                'expectedNumQueries' => 2,
+            ],
+            'belongs_many_many sub relation' => [
+                'eagerLoadRelation' => 'BelongsManyManyEagerLoadObjects.BelongsManyManySubEagerLoadObjects',
                 'expectedNumQueries' => 2,
             ],
         ];

--- a/tests/php/ORM/EagerLoadedListTest.php
+++ b/tests/php/ORM/EagerLoadedListTest.php
@@ -2422,4 +2422,26 @@ class EagerLoadedListTest extends SapphireTest
         }
         $this->assertCount($numExpected, $result, 'contents: ' . implode(', ', $result));
     }
+
+    public function testEmptyList()
+    {
+        $list = Category::get()->eagerLoad('Products');
+        $categoryA = $this->idFromFixture(Category::class, 'categorya');
+        $sawEmptyList = false;
+
+        /** @var Category $category */
+        foreach ($list as $category) {
+            $products = $category->Products();
+            $expected = $category->ID == $categoryA ? 2 : 0;
+            $sawEmptyList = $sawEmptyList || $products->count() === 0;
+
+            $this->assertInstanceOf(EagerLoadedList::class, $products);
+            $this->assertEquals($expected, $products->filter('Title:StartsWith', 'Product')->count());
+            $this->assertEquals($expected, $products->filterAny('Title:StartsWith', 'Product')->count());
+            $this->assertEquals(0, $products->exclude('Title:StartsWith', 'Product')->count());
+            $this->assertEquals(0, $products->excludeAny('Title:StartsWith', 'Product')->count());
+        }
+
+        $this->assertTrue($sawEmptyList, 'Expected at least one Category with an empty eager-loaded Products list');
+    }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
The EagerLoadedList currently throws an error when the list is empty and you try to filter it.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11893

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
