### PR TITLE
FIX SearchableDropdownTrait failing to filter empty values (fixes #11910)

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -371,7 +371,7 @@ trait SearchableDropdownTrait
             //   0 => '10',
             //   1 => '15'
             // ];
-            return array_map('intval', $arr);
+            return array_map('intval', array_filter($arr));
         }
         if ((is_string($value) || is_int($value)) && ctype_digit((string) $value) && $value != 0) {
             return [(int) $value];

--- a/tests/php/Forms/SearchableDropdownTraitTest.php
+++ b/tests/php/Forms/SearchableDropdownTraitTest.php
@@ -125,10 +125,6 @@ class SearchableDropdownTraitTest extends SapphireTest
     public function provideGetValueArray(): array
     {
         return [
-            'empty' => [
-                'value' => '',
-                'expected' => [],
-            ],
             'array single form builder' => [
                 'value' => ['label' => 'MyTitle15', 'value' => '10', 'selected' => false],
                 'expected' => [10],
@@ -140,13 +136,17 @@ class SearchableDropdownTraitTest extends SapphireTest
                 ],
                 'expected' => [10, 15],
             ],
+            'array simple ints' => [
+                'value' => [2, 4],
+                'expected' => [2, 4],
+            ],
+            'array simple strings' => [
+                'value' => ['6', '8'],
+                'expected' => [6, 8],
+            ],
             'string int' => [
                 'value' => '3',
                 'expected' => [3],
-            ],
-            'zero string' => [
-                'value' => '0',
-                'expected' => [],
             ],
             'datalist' => [
                 'value' => '<DataListValue>',
@@ -160,12 +160,32 @@ class SearchableDropdownTraitTest extends SapphireTest
                 'value' => new stdClass(),
                 'expected' => [],
             ],
+            'empty' => [
+                'value' => '',
+                'expected' => [],
+            ],
+            'zero string' => [
+                'value' => '0',
+                'expected' => [],
+            ],
             'negative int' => [
                 'value' => -1,
                 'expected' => [],
             ],
             'negative string int' => [
                 'value' => '-1',
+                'expected' => [],
+            ],
+            'array - empty' => [
+                'value' => [],
+                'expected' => [],
+            ],
+            'array - empty string' => [
+                'value' => [''],
+                'expected' => [],
+            ],
+            'array - zero string' => [
+                'value' => ['0'],
                 'expected' => [],
             ],
         ];


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Fix for #11910. Re-arranged test data provider to put all the “empty” value tests next to each other

## Manual testing steps
See reproduction steps in #11910

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11910

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
