### PR TITLE
ENH PHP 8.5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "guzzlehttp/psr7": "^2.7",
         "embed/embed": "^4.4.7",
         "greenlion/php-sql-parser": "^4.7.0",
-        "league/csv": "^9.18",
+        "league/csv": "^9.27",
         "m1/env": "^2.2.0",
         "masterminds/html5": "^2.9",
         "monolog/monolog": "^3.8",

--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -381,8 +381,9 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     public function getViewer($action)
     {
         // Hard-coded templates
-        if (isset($this->templates[$action]) && $this->templates[$action]) {
-            $templates = $this->templates[$action];
+        $key = $action ?? '';
+        if (isset($this->templates[$key]) && $this->templates[$key]) {
+            $templates = $this->templates[$key];
         } elseif (isset($this->templates['index']) && $this->templates['index']) {
             $templates = $this->templates['index'];
         } elseif ($this->template) {
@@ -481,7 +482,8 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      */
     public function hasActionTemplate($action)
     {
-        if (isset($this->templates[$action])) {
+        $key = $action ?? '';
+        if (isset($this->templates[$key])) {
             return true;
         }
 
@@ -489,7 +491,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
         $templates   = [];
 
         while ($parentClass != __CLASS__) {
-            $templates[] = strtok($parentClass ?? '', '_') . '_' . $action;
+            $templates[] = strtok($parentClass ?? '', '_') . '_' . $key;
             $parentClass = get_parent_class($parentClass ?? '');
         }
 

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -471,11 +471,11 @@ class ClassInfo implements Flushable
                         break;
 
                     case T_DNUMBER:
-                        $result = (double)$token[1];
+                        $result = (float) $token[1];
                         break;
 
                     case T_LNUMBER:
-                        $result = (int)$token[1];
+                        $result = (int) $token[1];
                         break;
 
                     case T_DOUBLE_ARROW:

--- a/src/Core/Convert.php
+++ b/src/Core/Convert.php
@@ -474,11 +474,13 @@ class Convert
     {
         $scales = ['B','K','M','G','T','P','E','Z','Y'];
         // Get scale
-        $scale = (int)floor(log($bytes ?? 0.0, 1024));
+        $value = floor(log($bytes ?? 0.0, 1024));
+        // Handle values such as `INF` and `NAN` which are "not representable as int"
+        // and emit a warning if cast to int.
+        $scale = is_finite($value) ? (int) $value : 0;
         if (!isset($scales[$scale])) {
             $scale = 2;
         }
-
         // Size
         $num = round($bytes / pow(1024, $scale), $decimal ?? 0);
         return $num . $scales[$scale];

--- a/src/Dev/CSSContentParser.php
+++ b/src/Dev/CSSContentParser.php
@@ -50,7 +50,7 @@ class CSSContentParser
         } elseif (@shell_exec('which tidy')) {
             // using tiny through cli
             $CLI_content = escapeshellarg($content ?? '');
-            $tidy = `echo $CLI_content | tidy --force-output 1 -n -q -utf8 -asxhtml -w 99999 2> /dev/null`;
+            $tidy = shell_exec("echo $CLI_content | tidy --force-output 1 -n -q -utf8 -asxhtml -w 99999 2> /dev/null");
             $tidy = str_replace('xmlns="http://www.w3.org/1999/xhtml"', '', $tidy ?? '');
             $tidy = str_replace('&#160;', '', $tidy ?? '');
         } else {

--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -76,7 +76,7 @@ class CsvBulkLoader extends BulkLoader
 
         try {
             $filepath = Director::getAbsFile($filepath);
-            $csvReader = Reader::createFromPath($filepath, 'r');
+            $csvReader = Reader::from($filepath);
             $csvReader->setDelimiter($this->delimiter);
             $csvReader->skipInputBOM();
 

--- a/src/Forms/CurrencyField.php
+++ b/src/Forms/CurrencyField.php
@@ -27,7 +27,7 @@ class CurrencyField extends TextField
             $value = 0.00;
         }
         $this->value = DBCurrency::config()->uninherited('currency_symbol')
-            . number_format((double)preg_replace('/[^0-9.\-]/', '', $value ?? ''), 2);
+            . number_format((float) preg_replace('/[^0-9.\-]/', '', $value ?? ''), 2);
         return $this;
     }
 

--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -179,7 +179,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
     {
         $csvColumns = $this->getExportColumnsForGridField($gridField);
 
-        $csvWriter = Writer::createFromFileObject(new \SplTempFileObject());
+        $csvWriter = Writer::from(new \SplTempFileObject());
         $csvWriter->setDelimiter($this->getCsvSeparator());
         $csvWriter->setEnclosure($this->getCsvEnclosure());
         $csvWriter->setEndOfLine("\r\n"); //use windows line endings for compatibility with some csv libraries

--- a/src/Forms/SingleLookupField.php
+++ b/src/Forms/SingleLookupField.php
@@ -32,7 +32,7 @@ class SingleLookupField extends SingleSelectField
      */
     protected function valueToLabel()
     {
-        $value = $this->value;
+        $value = $this->value ?? '';
         $source = $this->getSource();
         $source = ($source instanceof Map) ? $source->toArray() : $source;
 

--- a/src/Model/List/Map.php
+++ b/src/Model/List/Map.php
@@ -74,7 +74,8 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
         $array = [];
 
         foreach ($this as $k => $v) {
-            $array[$k] = $v;
+            $key = $k ?? '';
+            $array[$key] = $v;
         }
 
         return $array;
@@ -243,10 +244,11 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
         }
 
         foreach ($this->list as $record) {
-            if (isset($this->firstItems[$record->$keyField])) {
+            $key = $record->$keyField ?? '';
+            if (isset($this->firstItems[$key])) {
                 continue;
             }
-            if (isset($this->lastItems[$record->$keyField])) {
+            if (isset($this->lastItems[$key])) {
                 continue;
             }
             yield $this->extractValue($record, $this->keyField) => $this->extractValue($record, $this->valueField);

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -1481,7 +1481,7 @@ class DataQuery implements Resettable
      */
     public function setQueryParam($key, $value)
     {
-        $this->queryParams[$key] = $value;
+        $this->queryParams[$key ?? ''] = $value;
         return $this;
     }
 

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -40,14 +40,14 @@ class DBInt extends DBField
         parent::setValue($value, $record, $markChanged);
         // Cast string ints if they're valid
         if (is_string($this->value) && preg_match('/^-?\d+$/', $this->value)) {
-            // Ensure we can cast to int and back without loss of precision
-            // if not, keep the original value which will fail validation later
-            $stringIntValue = (string) (int) $value;
-            if ($stringIntValue !== $value) {
-                $this->value = $value;
+            // Use filter_var to check if the string fits in a PHP integer
+            // It will return false if it overflows e.g. is "9223372036854775808"
+            // meaning it's bigger than PHP_INT_MAX on 64-bit systems
+            $intValue = filter_var($value, FILTER_VALIDATE_INT);
+            if ($intValue !== false) {
+                $this->value = $intValue;
             } else {
-                // Cast valid string ints as ints
-                $this->value = (int) $value;
+                $this->value = $value;
             }
         }
         return $this;

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -747,7 +747,7 @@ class Group extends DataObject
             ->toArray();
         $code = $this->Code;
         $count = 2;
-        while (isset($currentGroups[$code])) {
+        while (isset($currentGroups[$code ?? ''])) {
             $code = $this->Code . '-' . $count;
             $count++;
         }

--- a/tests/php/Control/CookieJarTest.php
+++ b/tests/php/Control/CookieJarTest.php
@@ -176,8 +176,6 @@ class CookieJarTest extends SapphireTest
     {
         $cookieJar = new CookieJar();
         $methodCookieIsSecure = new ReflectionMethod($cookieJar, 'cookieIsSecure');
-        $methodCookieIsSecure->setAccessible(true);
-
         $this->assertTrue($methodCookieIsSecure->invoke($cookieJar, 'None', false));
         $this->assertTrue($methodCookieIsSecure->invoke($cookieJar, 'None', true));
         $this->assertTrue($methodCookieIsSecure->invoke($cookieJar, 'Lax', true));

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -498,8 +498,6 @@ class EmailTest extends SapphireTest
         $email = new Email();
         $class = new \ReflectionClass(Email::class);
         $method = $class->getMethod('getDefaultFrom');
-        $method->setAccessible(true);
-
         // default to no-reply@mydomain.com if admin_email config not set
         Email::config()->set('admin_email', null);
         $this->assertSame('no-reply@www.mysite.com', $method->invokeArgs($email, []));
@@ -526,7 +524,6 @@ class EmailTest extends SapphireTest
     public function testCreateAddressArray(string|array $address, string $name, array $expected): void
     {
         $method = new \ReflectionMethod(Email::class, 'createAddressArray');
-        $method->setAccessible(true);
         $obj = new Email();
         $actual = $method->invoke($obj, $address, $name);
         for ($i = 0; $i < count($expected); $i++) {

--- a/tests/php/Control/HTTPRequestTest.php
+++ b/tests/php/Control/HTTPRequestTest.php
@@ -346,8 +346,6 @@ class HTTPRequestTest extends SapphireTest
     {
         $req = new TrustedProxyMiddleware();
         $reflectionMethod = new ReflectionMethod($req, 'getIPFromHeaderValue');
-        $reflectionMethod->setAccessible(true);
-
         $headers = [
             '80.79.208.21, 149.126.76.1, 10.51.0.68' => '80.79.208.21',
             '52.19.19.103, 10.51.0.49' => '52.19.19.103',

--- a/tests/php/Control/SessionHandler/CacheSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/CacheSessionHandlerTest.php
@@ -133,7 +133,6 @@ class CacheSessionHandlerTest extends SapphireTest
         $this->assertTrue($handler->updateTimestamp(CacheSessionHandlerTest::ID_EXISTING, 'new content'));
         $this->assertTrue($cache->has(CacheSessionHandlerTest::ID_EXISTING));
         $reflectionExpiries = new ReflectionProperty($arrayAdapter, 'expiries');
-        $reflectionExpiries->setAccessible(true);
         $expiry = $reflectionExpiries->getValue($arrayAdapter)[CacheSessionHandlerTest::ID_EXISTING];
 
         // 999999 is way more than the number of seconds the session should live for

--- a/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
+++ b/tests/php/Control/SessionHandler/FileSessionHandlerTest.php
@@ -113,22 +113,18 @@ class FileSessionHandlerTest extends SapphireTest
         // Set path
         $handler = new FileSessionHandler();
         $reflectionMethod = new ReflectionMethod($handler, 'setSavePath');
-        $reflectionMethod->setAccessible(true);
         $reflectionMethod->invoke($handler, $sessionSavePath);
 
         // Check baseDir
         $reflectionBaseDir = new ReflectionProperty($handler, 'baseDir');
-        $reflectionBaseDir->setAccessible(true);
         $this->assertSame($baseDir, $reflectionBaseDir->getValue($handler));
 
         // Check numSubDirs
         $reflectionNumSubDirs = new ReflectionProperty($handler, 'numSubDirs');
-        $reflectionNumSubDirs->setAccessible(true);
         $this->assertSame($numSubDirs, $reflectionNumSubDirs->getValue($handler));
 
         // Check mode
         $reflectionMode = new ReflectionProperty($handler, 'mode');
-        $reflectionMode->setAccessible(true);
         $this->assertSame($mode, $reflectionMode->getValue($handler));
     }
 
@@ -153,11 +149,9 @@ class FileSessionHandlerTest extends SapphireTest
     {
         $handler = new FileSessionHandler();
         $reflectionSetSavePath = new ReflectionMethod($handler, 'setSavePath');
-        $reflectionSetSavePath->setAccessible(true);
         $reflectionSetSavePath->invoke($handler, $savePath);
 
         $reflectionGetFilePath = new ReflectionMethod($handler, 'getFilePath');
-        $reflectionGetFilePath->setAccessible(true);
         $this->assertSame($expected, $reflectionGetFilePath->invoke($handler, $sessionID));
     }
 
@@ -196,8 +190,6 @@ class FileSessionHandlerTest extends SapphireTest
         $handler = new FileSessionHandler();
         $handler->open($savePath, 'PHPSESSID');
         $reflectionNeedsPermissionUpdate = new ReflectionMethod($handler, 'needsPermissionUpdate');
-        $reflectionNeedsPermissionUpdate->setAccessible(true);
-
         try {
             if ($createFileBeforeTest) {
                 file_put_contents($sessionFilePath, 'original content');
@@ -235,7 +227,6 @@ class FileSessionHandlerTest extends SapphireTest
             $this->withSessionExpiry($sessionFilePath, function () use ($isExpired, $sessionFilePath) {
                 $handler = new FileSessionHandler();
                 $reflectionIsSessionExpired = new ReflectionMethod($handler, 'isSessionExpired');
-                $reflectionIsSessionExpired->setAccessible(true);
                 $this->assertSame($isExpired, $reflectionIsSessionExpired->invoke($handler, $sessionFilePath));
             }, $isExpired);
         } finally {
@@ -250,8 +241,6 @@ class FileSessionHandlerTest extends SapphireTest
 
         $handler = new FileSessionHandler();
         $reflectionIsSessionExpired = new ReflectionMethod($handler, 'isSessionExpired');
-        $reflectionIsSessionExpired->setAccessible(true);
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not read modified time of session file');
         $reflectionIsSessionExpired->invoke($handler, $sessionFilePath);

--- a/tests/php/Control/SessionTest.php
+++ b/tests/php/Control/SessionTest.php
@@ -349,8 +349,6 @@ class SessionTest extends SapphireTest
     {
         $session = new Session(null);
         $methodIsCookieSecure = new ReflectionMethod($session, 'isCookieSecure');
-        $methodIsCookieSecure->setAccessible(true);
-
         Config::modify()->set(Session::class, 'cookie_secure', false);
         $this->assertFalse($methodIsCookieSecure->invoke($session, 'Lax', true));
         $this->assertFalse($methodIsCookieSecure->invoke($session, 'Lax', false));
@@ -368,8 +366,6 @@ class SessionTest extends SapphireTest
     {
         $session = new Session(null);
         $methodBuildCookieParams = new ReflectionMethod($session, 'buildCookieParams');
-        $methodBuildCookieParams->setAccessible(true);
-
         $params = $methodBuildCookieParams->invoke($session, new NullHTTPRequest());
         $this->assertSame(
             [
@@ -452,8 +448,6 @@ class SessionTest extends SapphireTest
     ): void {
         $session = new Session(null);
         $methodBuildCookieParams = new ReflectionMethod($session, 'buildCookieParams');
-        $methodBuildCookieParams->setAccessible(true);
-
         Config::modify()->set(Session::class, 'cookie_secure', $secure);
         Config::modify()->set(Session::class, 'cookie_samesite', $sameSite);
         Config::modify()->set(Director::class, 'alternate_base_url', $alternateBase);
@@ -471,8 +465,6 @@ class SessionTest extends SapphireTest
     {
         $session = new Session(null);
         $methodBuildCookieParams = new ReflectionMethod($session, 'buildCookieParams');
-        $methodBuildCookieParams->setAccessible(true);
-
         // Throw an exception when a warning is logged so we can catch it
         $mockLogger = $this->getMockBuilder(Logger::class)->setConstructorArgs(['testLogger'])->getMock();
         $catchMessage = 'A warning was logged';
@@ -493,8 +485,6 @@ class SessionTest extends SapphireTest
     {
         $session = new Session(null);
         $methodBuildCookieParams = new ReflectionMethod($session, 'buildCookieParams');
-        $methodBuildCookieParams->setAccessible(true);
-
         $this->expectException(LogicException::class);
         Config::modify()->set(Session::class, 'cookie_samesite', 'invalid');
         $methodBuildCookieParams->invoke($session, new NullHTTPRequest());

--- a/tests/php/Core/Cache/DefaultCacheFactoryTest.php
+++ b/tests/php/Core/Cache/DefaultCacheFactoryTest.php
@@ -97,7 +97,6 @@ class DefaultCacheFactoryTest extends SapphireTest
             $psr16Wrapper = $factory->create('test-cache', $args);
 
             $reflectionPoolProperty = new ReflectionProperty($psr16Wrapper, 'pool');
-            $reflectionPoolProperty->setAccessible(true);
             $cacheBucket = $reflectionPoolProperty->getValue($psr16Wrapper);
 
             if (!$inMemoryCacheFactory || (isset($args['useInMemoryCache']) && !$args['useInMemoryCache'])) {
@@ -106,7 +105,6 @@ class DefaultCacheFactoryTest extends SapphireTest
                 $this->assertInstanceOf(ChainAdapter::class, $cacheBucket);
 
                 $reflectionAdaptersProperty = new ReflectionProperty($cacheBucket, 'adapters');
-                $reflectionAdaptersProperty->setAccessible(true);
                 $adapters = $reflectionAdaptersProperty->getValue($cacheBucket);
 
                 $this->assertCount(2, $adapters);
@@ -132,7 +130,6 @@ class DefaultCacheFactoryTest extends SapphireTest
 
                 // Check the adapter got the right logger
                 $reflectionLoggerProperty = new ReflectionProperty($inMemoryCache, 'logger');
-                $reflectionLoggerProperty->setAccessible(true);
                 $this->assertTrue($logger === $reflectionLoggerProperty->getValue($inMemoryCache));
             }
 
@@ -144,7 +141,6 @@ class DefaultCacheFactoryTest extends SapphireTest
             }
             // Check the adapter got the right logger
             $reflectionLoggerProperty = new ReflectionProperty($filesystemCache, 'logger');
-            $reflectionLoggerProperty->setAccessible(true);
             $this->assertTrue($logger === $reflectionLoggerProperty->getValue($filesystemCache));
         } finally {
             Environment::setEnv('SS_IN_MEMORY_CACHE_FACTORY', $oldFactoryValue);

--- a/tests/php/Core/KernelTest.php
+++ b/tests/php/Core/KernelTest.php
@@ -107,7 +107,6 @@ class KernelTest extends SapphireTest
         // Boot the database environment variables
         $reflector = new ReflectionObject($coreKernel);
         $method = $reflector->getMethod('bootDatabaseEnvVars');
-        $method->setAccessible(true);
         $method->invoke($coreKernel);
         // Assert DB config was updated
         $default = DB::getConfig(DB::CONN_PRIMARY);

--- a/tests/php/Core/Manifest/NamespacedClassManifestTest.php
+++ b/tests/php/Core/Manifest/NamespacedClassManifestTest.php
@@ -54,7 +54,6 @@ class NamespacedClassManifestTest extends SapphireTest
         // descendants of the core classes we want to test against - this is a limitation of the test manifest not
         // including all core classes
         $method = new ReflectionMethod($this->manifest, 'coalesceDescendants');
-        $method->setAccessible(true);
         $method->invoke($this->manifest, DataQuery::class);
         $classes = ClassInfo::subclassesFor(DataQuery::class);
         $this->assertContains(

--- a/tests/php/Core/PhpSyntaxTest.php
+++ b/tests/php/Core/PhpSyntaxTest.php
@@ -55,6 +55,6 @@ class PhpSyntaxTest extends SapphireTest
             BASE_PATH,
             escapeshellarg(".{$ext}\$")
         );
-        return explode("\n", trim(`$cmd`));
+        return explode("\n", trim(shell_exec($cmd)));
     }
 }

--- a/tests/php/Dev/BacktraceTest.php
+++ b/tests/php/Dev/BacktraceTest.php
@@ -162,7 +162,6 @@ class BacktraceTest extends SapphireTest
     public function testMatchesFilterableClass(string $className, string $filterableClass, bool $expected, string $message): void
     {
         $reflectionMethod = new ReflectionMethod(Backtrace::class, 'matchesFilterableClass');
-        $reflectionMethod->setAccessible(true);
         $this->assertSame($expected, $reflectionMethod->invoke(null, $className, $filterableClass), $message);
     }
 }

--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -521,8 +521,6 @@ class DeprecationTest extends SapphireTest
     public function testVarAsBoolean($rawValue, bool $expected)
     {
         $reflectionVarAsBoolean = new ReflectionMethod(Deprecation::class, 'varAsBoolean');
-        $reflectionVarAsBoolean->setAccessible(true);
-
         $this->assertSame($expected, $reflectionVarAsBoolean->invoke(null, $rawValue));
     }
 
@@ -600,7 +598,6 @@ class DeprecationTest extends SapphireTest
         $origMode = $kernel->getEnvironment();
         $origEnvEnabled = Environment::getEnv('SS_DEPRECATION_ENABLED');
         $reflectionEnabled = new ReflectionProperty(Deprecation::class, 'currentlyEnabled');
-        $reflectionEnabled->setAccessible(true);
         $origStaticEnabled = $reflectionEnabled->getValue();
 
         try {

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -320,7 +320,6 @@ class SapphireTestTest extends SapphireTest
         i18n::set_locale('ab_CD');
         i18n::config()->set('default_locale', 'ab_CD');
         $method = new ReflectionMethod(SapphireTest::class, 'setI18nLocale');
-        $method->setAccessible(true);
         $obj = new class($doSet, $supported) extends SapphireTest
         {
             private string $supported;

--- a/tests/php/Dev/TaskRunnerTest.php
+++ b/tests/php/Dev/TaskRunnerTest.php
@@ -13,8 +13,6 @@ class TaskRunnerTest extends SapphireTest
     {
         $runner = new TaskRunner();
         $method = new ReflectionMethod($runner, 'taskEnabled');
-        $method->setAccessible(true);
-
         $this->assertTrue(
             $method->invoke($runner, TaskRunnerTest\TaskRunnerTest_EnabledTask::class),
             'Enabled task incorrectly marked as disabled'

--- a/tests/php/Forms/CompositeValidatorTest.php
+++ b/tests/php/Forms/CompositeValidatorTest.php
@@ -55,8 +55,6 @@ class CompositeValidatorTest extends SapphireTest
 
         $reflectionClass = new ReflectionClass(CompositeValidator::class);
         $property = $reflectionClass->getProperty('form');
-        $property->setAccessible(true);
-
         $compositeValidator = new CompositeValidator();
         $validator = new TestValidator();
 

--- a/tests/php/Forms/ConfirmedPasswordFieldTest.php
+++ b/tests/php/Forms/ConfirmedPasswordFieldTest.php
@@ -808,7 +808,6 @@ class ConfirmedPasswordFieldTest extends SapphireTest
         $field->setRequireStrongPassword($requireStrong);
         $field->setIsOnMemberForm($onMemberForm);
         $refl = new ReflectionMethod($field, 'getMinPasswordStrengthForEvaluation');
-        $refl->setAccessible(true);
         $actual = $refl->invoke($field);
         $this->assertSame($expected, $actual);
     }
@@ -848,7 +847,6 @@ class ConfirmedPasswordFieldTest extends SapphireTest
     {
         $field = new ConfirmedPasswordField('Test');
         $refl = new ReflectionMethod($field, 'getStrengthLabel');
-        $refl->setAccessible(true);
         $actual = $refl->invoke($field, $strength);
         $this->assertSame($expected, $actual);
     }

--- a/tests/php/Forms/DateFieldTest.php
+++ b/tests/php/Forms/DateFieldTest.php
@@ -328,7 +328,6 @@ class DateFieldTest extends SapphireTest
     {
         $field = new DateField('Date');
         $method = new ReflectionMethod($field, 'tidyInternal');
-        $method->setAccessible(true);
         $actual = $method->invoke($field, $date, $returnNullOnFailure);
         $this->assertEquals($expected, $actual);
     }

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -591,7 +591,6 @@ class DatetimeFieldTest extends SapphireTest
     {
         $field = new DatetimeField('Date');
         $method = new ReflectionMethod($field, 'tidyInternal');
-        $method->setAccessible(true);
         $actual = $method->invoke($field, $date, $returnNullOnFailure);
         $this->assertEquals($expected, $actual);
     }

--- a/tests/php/Forms/FileFieldTest.php
+++ b/tests/php/Forms/FileFieldTest.php
@@ -105,7 +105,6 @@ class FileFieldTest extends FunctionalTest
         $field->setAllowedExtensions('jpg', 'png');
 
         $method = new ReflectionMethod($field, 'getAcceptFileTypes');
-        $method->setAccessible(true);
         $allowed = $method->invoke($field);
 
         $expected = ['.jpg', '.png', 'image/jpeg', 'image/png'];

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -984,7 +984,6 @@ class FormFieldTest extends SapphireTest
             $expected = $expectedFieldValidators[$class];
             $field = $this->instantiateFormField($class);
             $method = new ReflectionMethod($class, 'getFieldValidators');
-            $method->setAccessible(true);
             $config = $method->invoke($field);
             $actual = array_map('get_class', $config);
             $this->assertSame($expected, $actual, $class);

--- a/tests/php/Forms/GridField/GridFieldDeleteActionTest.php
+++ b/tests/php/Forms/GridField/GridFieldDeleteActionTest.php
@@ -294,7 +294,6 @@ class GridFieldDeleteActionTest extends SapphireTest
 
         // Calling the method will throw an exception.
         $reflectionMethod = new ReflectionMethod($component, 'getRemoveAction');
-        $reflectionMethod->setAccessible(true);
         $reflectionMethod->invokeArgs($component, [$gridField, new ArrayData(), '']);
     }
 }

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest.php
@@ -145,7 +145,6 @@ class GridFieldDetailFormTest extends FunctionalTest
         // Trigger creation of the item edit form
         $reflectionDetailForm = new \ReflectionClass($detailForm);
         $reflectionMethod = $reflectionDetailForm->getMethod('getItemRequestHandler');
-        $reflectionMethod->setAccessible(true);
         $itemrequest = $reflectionMethod->invoke($detailForm, $gridField, $record, new Controller());
         $itemrequest->ItemEditForm();
 
@@ -169,7 +168,6 @@ class GridFieldDetailFormTest extends FunctionalTest
         // Trigger creation of the item edit form
         $reflectionDetailForm = new \ReflectionClass($detailForm);
         $reflectionMethod = $reflectionDetailForm->getMethod('getItemRequestHandler');
-        $reflectionMethod->setAccessible(true);
         $itemrequest = $reflectionMethod->invoke($detailForm, $gridField, $record, new Controller());
         $itemrequest->ItemEditForm();
 
@@ -525,7 +523,6 @@ class GridFieldDetailFormTest extends FunctionalTest
         $request->match(Controller::join_links($gridField->Link(), 'item/$ID'));
 
         $reflectionMethod = new ReflectionMethod($component, 'getRecordFromRequest');
-        $reflectionMethod->setAccessible(true);
         $this->assertSame($hasRecord, (bool) $reflectionMethod->invoke($component, $gridField, $request));
     }
 
@@ -559,7 +556,6 @@ class GridFieldDetailFormTest extends FunctionalTest
         $request->match(Controller::join_links($gridField->Link(), 'item/$ID'));
 
         $reflectionMethod = new ReflectionMethod($component, 'getRecordFromRequest');
-        $reflectionMethod->setAccessible(true);
         $this->assertEquals(new ArrayDataWithID(['ID' => 0]), $reflectionMethod->invoke($component, $gridField, $request));
     }
 
@@ -596,7 +592,6 @@ class GridFieldDetailFormTest extends FunctionalTest
         $this->expectExceptionMessage(ArrayData::class . ' must have an ID field.');
 
         $reflectionMethod = new ReflectionMethod($component, 'getRecordFromRequest');
-        $reflectionMethod->setAccessible(true);
         $reflectionMethod->invoke($component, $gridField, $request);
     }
 }

--- a/tests/php/Forms/GridField/GridFieldDetailForm_ItemRequestTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailForm_ItemRequestTest.php
@@ -86,12 +86,10 @@ class GridFieldDetailForm_ItemRequestTest extends SapphireTest
         $itemRequest->setRequest($request);
         // Assert method
         $refl = new ReflectionMethod($itemRequest, 'getGridFieldItemAdjacencies');
-        $refl->setAccessible(true);
         $expectedData = [103, 104, 105, 106, 107];
         $this->assertSame($expectedData, $refl->invoke($itemRequest));
         // Assert cache
         $refl = new ReflectionProperty($itemRequest, 'cachedGridFieldItemAdjacencies');
-        $refl->setAccessible(true);
         $this->assertSame(
             ['9cffefcf339420d11129b3220eccf141' => $expectedData],
             $refl->getValue($itemRequest)

--- a/tests/php/Forms/GridField/GridFieldExportButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldExportButtonTest.php
@@ -215,13 +215,12 @@ class GridFieldExportButtonTest extends SapphireTest
         );
 
         $reflectionMethod = new ReflectionMethod($component, 'getExportColumnsForGridField');
-        $reflectionMethod->setAccessible(true);
         $reflectionMethod->invoke($component, $gridField);
     }
 
     protected function createReader($string)
     {
-        $reader = Reader::createFromString($string);
+        $reader = Reader::fromString($string);
 
         // Explicitly set the output BOM in league/csv 9
         if (method_exists($reader, 'getContent')) {

--- a/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
@@ -287,7 +287,6 @@ class GridFieldPrintButtonTest extends SapphireTest
         );
 
         $reflectionMethod = new ReflectionMethod($component, 'getPrintColumnsForGridField');
-        $reflectionMethod->setAccessible(true);
         $reflectionMethod->invoke($component, $gridField);
     }
 }

--- a/tests/php/Forms/TimeFieldTest.php
+++ b/tests/php/Forms/TimeFieldTest.php
@@ -223,7 +223,6 @@ class TimeFieldTest extends SapphireTest
     {
         $field = new TimeField('Time');
         $method = new ReflectionMethod($field, 'tidyInternal');
-        $method->setAccessible(true);
         $actual = $method->invoke($field, $time, $returnNullOnFailure);
         $this->assertSame($expected, $actual);
     }

--- a/tests/php/Logging/ErrorOutputHandlerTest.php
+++ b/tests/php/Logging/ErrorOutputHandlerTest.php
@@ -156,7 +156,6 @@ class ErrorOutputHandlerTest extends SapphireTest
         bool $expected
     ) {
         $reflectionShouldShow = new ReflectionMethod(ErrorOutputHandler::class, 'shouldShowError');
-        $reflectionShouldShow->setAccessible(true);
         $reflectionDeprecation = new ReflectionClass(Deprecation::class);
 
         $cliShouldShowOrig = Deprecation::shouldShowForCli();

--- a/tests/php/Model/ModelDataTest.php
+++ b/tests/php/Model/ModelDataTest.php
@@ -204,7 +204,6 @@ class ModelDataTest extends SapphireTest
     public function testIsAccessibleMethod()
     {
         $reflectionMethod = new ReflectionMethod(ModelData::class, 'isAccessibleMethod');
-        $reflectionMethod->setAccessible(true);
         $object = new ModelDataTestObject();
         $modelData = new ModelData();
 
@@ -236,7 +235,6 @@ class ModelDataTest extends SapphireTest
     public function testIsAccessibleProperty()
     {
         $reflectionMethod = new ReflectionMethod(ModelData::class, 'isAccessibleProperty');
-        $reflectionMethod->setAccessible(true);
         $object = new ModelDataTestObject();
 
         $output = $reflectionMethod->invokeArgs($object, ['privateProperty']);

--- a/tests/php/ORM/Connect/DBQueryBuilderTest.php
+++ b/tests/php/ORM/Connect/DBQueryBuilderTest.php
@@ -53,8 +53,6 @@ class DBQueryBuilderTest extends SapphireTest
     {
         $queryBuilder = new DBQueryBuilder();
         $reflectionMethod = new ReflectionMethod($queryBuilder, 'shouldBuildTraceComment');
-        $reflectionMethod->setAccessible(true);
-
         if ($envValue !== null) {
             Environment::setEnv('SS_TRACE_DB_QUERY_ORIGIN', $envValue);
         }

--- a/tests/php/ORM/DBFieldTest.php
+++ b/tests/php/ORM/DBFieldTest.php
@@ -587,7 +587,6 @@ class DBFieldTest extends SapphireTest
             }
             $expected = $expectedFieldValidators[$class];
             $method = new ReflectionMethod($class, 'getFieldValidators');
-            $method->setAccessible(true);
             $obj = new $class('MyField');
             $actual = array_map('get_class', $method->invoke($obj));
             $this->assertSame($expected, $actual, $class);

--- a/tests/php/ORM/DBSchemaManagerTest.php
+++ b/tests/php/ORM/DBSchemaManagerTest.php
@@ -59,7 +59,6 @@ class DBSchemaManagerTest extends SapphireTest
 
         $manager = $this->getConcreteSchemaManager();
         $reflectionCanCheck = new ReflectionMethod($manager, 'canCheckAndRepairTable');
-        $reflectionCanCheck->setAccessible(true);
         $result = $reflectionCanCheck->invoke($manager, $tableName);
 
         $this->assertSame($expected, $result);

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -3032,7 +3032,6 @@ class DataObjectTest extends SapphireTest
     {
         $dataObjectClass = new DataObject();
         $method = new ReflectionMethod($dataObjectClass, 'getDatabaseBackedField');
-        $method->setAccessible(true);
         $class = new Team([]);
 
         $databaseBackedField = $method->invokeArgs($class, [$fieldPath]);

--- a/tests/php/ORM/Search/BasicSearchContextTest.php
+++ b/tests/php/ORM/Search/BasicSearchContextTest.php
@@ -138,8 +138,6 @@ class BasicSearchContextTest extends SapphireTest
     {
         $context = new BasicSearchContext(ArrayData::class);
         $reflectionApplySearchFilters = new ReflectionMethod($context, 'applySearchFilters');
-        $reflectionApplySearchFilters->setAccessible(true);
-
         if ($filters) {
             $context->setFilters($filters);
         }
@@ -178,8 +176,6 @@ class BasicSearchContextTest extends SapphireTest
     {
         $context = new BasicSearchContext(ArrayData::class);
         $reflectionGetGeneralSearchFilterTerm = new ReflectionMethod($context, 'getGeneralSearchFilterTerm');
-        $reflectionGetGeneralSearchFilterTerm->setAccessible(true);
-
         if ($fieldFilter) {
             $context->setFilters(['MyField' => $fieldFilter]);
         }

--- a/tests/php/ORM/Search/SearchContextTest.php
+++ b/tests/php/ORM/Search/SearchContextTest.php
@@ -689,8 +689,6 @@ class SearchContextTest extends SapphireTest
         $general1 = $this->objFromFixture(SearchContextTest\GeneralSearch::class, 'general1');
         $context = $general1->getDefaultSearchContext();
         $getSearchFilterReflection = new ReflectionMethod($context, 'getGeneralSearchFilter');
-        $getSearchFilterReflection->setAccessible(true);
-
         // By default, uses the PartialMatchFilter.
         $this->assertSame(
             PartialMatchFilter::class,

--- a/tests/php/Security/InheritedPermissionsTest.php
+++ b/tests/php/Security/InheritedPermissionsTest.php
@@ -473,8 +473,6 @@ class InheritedPermissionsTest extends SapphireTest
     {
         $reflection = new ReflectionClass(InheritedPermissions::class);
         $method = $reflection->getMethod('generateCacheKey');
-        $method->setAccessible(true);
-
         return $method->invokeArgs($inst, [$type, $memberID]);
     }
 }

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1692,7 +1692,6 @@ class MemberTest extends FunctionalTest
 
         $ext = new MemberTest\ValidatorExtension();
         $method = new ReflectionMethod(MemberTest\ValidatorExtension::class, 'updateValidator');
-        $method->setAccessible(true);
         $method->invokeArgs($ext, [$validator]);
 
         $pass = $validator->php(

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -856,7 +856,6 @@ class SecurityTest extends FunctionalTest
         $security->setRequest($request);
         $reflection = new \ReflectionClass($security);
         $method = $reflection->getMethod('getResponseController');
-        $method->setAccessible(true);
         $result = $method->invoke($security, 'Page');
 
         // Ensure page shares the same controller as security

--- a/tests/php/View/Shortcodes/EmbedShortcodeProviderTest.php
+++ b/tests/php/View/Shortcodes/EmbedShortcodeProviderTest.php
@@ -176,10 +176,8 @@ class EmbedShortcodeProviderTest extends EmbedUnitTest
         $provider = new EmbedShortcodeProvider();
         $reflector = new \ReflectionClass(EmbedShortcodeProvider::class);
         $method = $reflector->getMethod('getCache');
-        $method->setAccessible(true);
         $cache = $method->invokeArgs($provider, []);
         $method = $reflector->getMethod('deriveCacheKey');
-        $method->setAccessible(true);
         $class = 'leftAlone ss-htmleditorfield-file embed';
         $width = '480';
         $height = '270';


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
- Using null as an array offset or when calling array_key_exists() is now deprecated.
- Non-canonical cast names (boolean), (integer), (double), and (binary) have been deprecated.
- Casting floats that are not representable as ints now emits a warning.
- The backtick operator as an alias for shell_exec() has been deprecated.