### PR TITLE
DEP Add symfony/event-dispatcher:^7 to requirements (fixes #11913)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "symfony/config": "^7.0",
         "symfony/console": "^7.0",
         "symfony/dom-crawler": "^7.0",
+        "symfony/event-dispatcher": "^6|^7",
         "symfony/filesystem": "^7.0",
         "symfony/http-foundation": "^7.0",
         "symfony/intl": "^7.0",


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Fix for https://github.com/silverstripe/silverstripe-framework/issues/11913

tldr version: with PHP 8.4 `symfony/event-dispatcher` version 8 gets installed, which has BC breaks in APIs we’re depending on. Adding this forces version 7 like all the other Symfony components we rely on.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
See https://github.com/silverstripe/silverstripe-framework/issues/11913#issuecomment-3586247839

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11913

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
