### PR TITLE
MNT Don't fail test for unrelated line number change

### DIFF
--- a/tests/php/i18n/YamlReaderTest.php
+++ b/tests/php/i18n/YamlReaderTest.php
@@ -43,7 +43,7 @@ class YamlReaderTest extends SapphireTest
         $path = __DIR__ . '/i18nTest/_fakewebroot/i18ntestmodule/lang/en_corrupt.yml';
         $this->expectException(InvalidResourceException::class);
         $regex_path = str_replace('.', '\.', $path ?? '');
-        $this->expectExceptionMessageMatches('@^Error parsing YAML, invalid file "' . $regex_path . '"\. Message: ([\w ].*) line 5 @');
+        $this->expectExceptionMessageMatches('@^Error parsing YAML, invalid file "' . $regex_path . '"\. Message: ([\w ].*) line \d@');
         $reader = new YamlReader();
         $reader->read('en', $path);
     }


### PR DESCRIPTION
symfony/yaml changed which line it thinks the error is on - arguably the change is wrong, but arguably the line number was already wrong anyway (the actual error is on line 4, but we used to expect line 5, and it changed to reporting line 6).

We shouldn't care what line symfony is reporting about - what really matters is that the error we expect is the error that is thrown.

> [!IMPORTANT]
> Intentionally targetting `6.0` since this doesn't affect projects but does make CI green.
> `6.0` is still supported for security fixes so we should ideally keep CI green on that branch.
>
> Doesn't affect 5.4 because this only started failing with `symfony/yaml 7.4.0` which can't be installed with framework 5.4

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11915