### PR TITLE
FIX Get valid link with CompositeField::Link() method

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -377,7 +377,7 @@ class FormField extends RequestHandler
             );
         }
 
-        $link = Controller::join_links($this->form->FormAction(), 'field/' . $this->name, $action);
+        $link = Controller::join_links($this->form->FormAction(), 'field/' . $this->getName(), $action);
         $this->extend('updateLink', $link, $action);
         return $link;
     }

--- a/tests/php/Forms/CompositeFieldTest.php
+++ b/tests/php/Forms/CompositeFieldTest.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\Form;
 
 class CompositeFieldTest extends SapphireTest
 {
@@ -269,5 +270,16 @@ class CompositeFieldTest extends SapphireTest
         $this->assertStringContainsString(CompositeField::class . ' (TestComposite)', $result);
         $this->assertStringContainsString('TestTextField', $result);
         $this->assertStringContainsString('<ul', $result, 'Result should be formatted as a <ul>');
+    }
+
+    public function testLink(): void
+    {
+        $fieldOne = TextField::create('One');
+        $fieldTwo = TextField::create('Two');
+        $field = new CompositeField($fieldOne, $fieldTwo);
+        $form = new Form(null, 'Test', new FieldList(), new FieldList());
+        $form->setFormAction('foo');
+        $field->setForm($form);
+        $this->assertSame('foo/field/OneTwo/bar', $field->Link('bar'));
     }
 }

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -635,7 +635,7 @@ class FormFieldTest extends SapphireTest
     public function testLinkWithForm()
     {
         $field = new FormField('Test');
-        $form = new Form(null, 'Test', new FieldList, new FieldList);
+        $form = new Form(null, 'Test', new FieldList(), new FieldList());
         $form->setFormAction('foo');
         $field->setForm($form);
         $this->assertSame('foo/field/Test/bar', $field->Link('bar'));


### PR DESCRIPTION
99% of the time this won't matter, but a custom CompositeField that has some AJAX query on it will need to be link-to-able.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11917