### PR TITLE
FIX Make SearchableDropdownTrait::dataValue() return correct value

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -435,6 +435,18 @@ trait SearchableDropdownTrait
         return $this->extendValidationResult(true, $validator);
     }
 
+    public function dataValue()
+    {
+        $name = $this->getName();
+        $ids = $this->getValueArray();
+        // This is how we distinguish between single and multi fields in saveInto()
+        // so use the same logic here.
+        if (substr($name, -2) === 'ID') {
+            return $ids[0] ?? 0;
+        }
+        return $ids;
+    }
+
     public function getSchemaDataType(): string
     {
         if ($this->isMultiple) {

--- a/tests/php/Forms/SearchableDropdownTraitTest.php
+++ b/tests/php/Forms/SearchableDropdownTraitTest.php
@@ -191,6 +191,73 @@ class SearchableDropdownTraitTest extends SapphireTest
         ];
     }
 
+    public static function provideDataValue(): array
+    {
+        // Note that not all combinations are tested - we mostly rely on testGetValueArray for the variations.
+        return [
+            'array single form builder' => [
+                'name' => 'MyFieldID',
+                'value' => ['label' => 'MyTitle15', 'value' => '10', 'selected' => false],
+                'expected' => 10,
+            ],
+            'array single form builder (multi field style name)' => [
+                'name' => 'MyField',
+                'value' => ['label' => 'MyTitle15', 'value' => '10', 'selected' => false],
+                'expected' => [10],
+            ],
+            'array simple int' => [
+                'name' => 'MyFieldID',
+                'value' => [2],
+                'expected' => 2,
+            ],
+            'array simple int (multi field style name)' => [
+                'name' => 'MyField',
+                'value' => [2],
+                'expected' => [2],
+            ],
+            'string int' => [
+                'name' => 'MyFieldID',
+                'value' => '3',
+                'expected' => 3,
+            ],
+            'string int (multi field style name)' => [
+                'name' => 'MyField',
+                'value' => '3',
+                'expected' => [3],
+            ],
+            'array - empty' => [
+                'name' => 'MyFieldID',
+                'value' => [],
+                'expected' => 0,
+            ],
+            'array - empty (multi field style name)' => [
+                'name' => 'MyField',
+                'value' => [],
+                'expected' => [],
+            ],
+            'array - zero string' => [
+                'name' => 'MyFieldID',
+                'value' => ['0'],
+                'expected' => 0,
+            ],
+            'array - zero string (multi field style name)' => [
+                'name' => 'MyField',
+                'value' => ['0'],
+                'expected' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataValue
+     */
+    public function testDataValue(string $name, mixed $value, int|array $expected): void
+    {
+        $field = new SearchableDropdownField($name, 'MyField', Team::get());
+        $field->setValue($value);
+        $this->assertSame($expected, $field->dataValue());
+    }
+
     public function testGetSchemaDataDefaults(): void
     {
         // setting a form is required for Link() which is called for 'optionUrl'


### PR DESCRIPTION
This method is meant to return a value that's ready for inserting into the database - for these form fields that means the raw ID value or array of ID values.

Previously this returned the raw submitted value, which was an associative array that included the value, the label, and whether the value was selected or not - which is not useful.

Need this for https://github.com/silverstripe/silverstripe-elemental/issues/445

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11919