### PR TITLE
FIX Don't choke on weird submitted values in NumericField

### DIFF
--- a/src/Forms/NumericField.php
+++ b/src/Forms/NumericField.php
@@ -136,21 +136,29 @@ class NumericField extends TextField
         // Save original value in case parse fails
         $this->originalValue = $value;
 
-        // Empty string is no-number (not 0)
-        if (mb_strlen($value ?? '') === 0) {
-            $this->value = null;
-            return $this;
+        // Handle string values (which is the normal case)
+        if (is_string($value)) {
+            // Empty string is no-number (not 0)
+            if (mb_strlen($value ?? '') === 0) {
+                $this->value = null;
+                return $this;
+            }
+
+            // Format number
+            $formatter = $this->getFormatter();
+            $parsed = 0;
+            // Note: may store literal `false` for invalid values
+            $value = $formatter->parse($value, $this->getNumberType(), $parsed);
+            // Ensure that entire string is parsed
+            if ($parsed < mb_strlen($this->originalValue ?? '')) {
+                $value = false;
+            }
         }
 
-        // Format number
-        $formatter = $this->getFormatter();
-        $parsed = 0;
-        $value = $formatter->parse($value, $this->getNumberType(), $parsed); // Note: may store literal `false` for invalid values
-        // Ensure that entire string is parsed
-        if ($parsed < mb_strlen($this->originalValue ?? '')) {
-            $value = false;
-        }
+        // Try to cast whatever the value currently is
+        // Any failures will be caught in the validation step
         $this->value = $this->cast($value);
+
         return $this;
     }
 
@@ -161,8 +169,9 @@ class NumericField extends TextField
      */
     public function getFormattedValue(): mixed
     {
-        // Show invalid value back to user in case of error
-        if ($this->value === null || $this->value === false) {
+        // Show invalid value back to user in case of error.
+        // Note that explicit "true" value should get transformed.
+        if (!is_string($this->value) && !is_numeric($this->value) && $this->value !== true) {
             return $this->originalValue;
         }
         $formatter = $this->getFormatter();

--- a/tests/php/Forms/NumericFieldTest.php
+++ b/tests/php/Forms/NumericFieldTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\Validation\RequiredFieldsValidator;
 use SilverStripe\i18n\i18n;
 use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
 
 class NumericFieldTest extends SapphireTest
 {
@@ -723,6 +724,35 @@ class NumericFieldTest extends SapphireTest
             $cleanedInput = $submittedValue;
         }
         $this->assertSame($cleanedInput, $field->getFormattedValue(), 'getFormattedValue()');
+    }
+
+    public static function provideSetSubmittedValueNonString(): array
+    {
+        return [
+            'array' => [
+                'value' => [1234],
+            ],
+            'object' => [
+                'value' => new stdClass(),
+            ],
+            'boolean true' => [
+                'value' => true,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetSubmittedValueNonString')]
+    public function testSetSubmittedValueNonString(mixed $value): void
+    {
+        $expectedFormatted = $value;
+        if ($value === true) {
+            // explicit true is an exception to the rule - it gets formatted to string 1
+            $expectedFormatted = '1';
+        }
+        $field = new NumericField('Number');
+        $field->setSubmittedValue($value);
+        $this->assertSame($value, $field->dataValue());
+        $this->assertSame($expectedFormatted, $field->getFormattedValue());
     }
 
     public static function provideDataType(): array


### PR DESCRIPTION
> [!IMPORTANT]
> The logic was changed on CMS 6 which is why this doesn't target `5.4`

While strings are what is expected from a form, someone might call `setSubmittedValue()` programatically. The field should handle that scenario in a sensible way and leave validation for the validation step.

This is further backed up by this comment in the `cast()` method (which is used in `setSubmittedValue()`:
> // If non-numeric, then return as-is. This will be caught by the validation.

... and by this comment in `setSubmittedValue()` itself:

> // Try to cast whatever the value currently is
> // Any failures will be caught in the validation step

Note that the specific use case I encountered this on was implementing https://github.com/silverstripe/silverstripe-elemental/issues/445

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11921