### PR TITLE
Performance improvements when preparing SELECT queries in ORM

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -115,6 +115,11 @@ class DataObjectSchema
     protected array $tableReadyClasses = [];
 
     /**
+     * Cache of table names for given class name and field combinations
+     */
+    protected array $tablesForFields = [];
+
+    /**
      * Clear cached table names
      */
     public function reset()
@@ -125,6 +130,7 @@ class DataObjectSchema
         $this->defaultDatabaseIndexes = [];
         $this->compositeFields = [];
         $this->tableReadyClasses = [];
+        $this->tablesForFields = [];
     }
 
     /**
@@ -935,11 +941,12 @@ class DataObjectSchema
      */
     public function tableForField($candidateClass, $fieldName)
     {
-        $class = $this->classForField($candidateClass, $fieldName);
-        if ($class) {
-            return $this->tableName($class);
+        $key = $candidateClass . '_' . $fieldName;
+        if (!array_key_exists($key, $this->tablesForFields)) {
+            $class = $this->classForField($candidateClass, $fieldName);
+            $this->tablesForFields[$key] = $class ? $this->tableName($class) : null;
         }
-        return null;
+        return $this->tablesForFields[$key];
     }
 
     /**

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM;
 
 use Exception;
 use InvalidArgumentException;
+use ReflectionException;
 use ReflectionMethod;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
@@ -727,30 +728,25 @@ class DataQuery implements Resettable
     /**
      * This method determines whether a subclass of DBField has overridden the DBField::addToQuery() method to
      * implement custom logic. This allows selectColumnsFromTable() to skip the relatively expensive step of
-     * building singleton objects to call the method if it will have no effect
+     * building singleton objects to call the method if it has no effect
      *
      * @param string $dbFieldSpec A string like "Varchar(255)"
-     * @return bool
+     * @throws Exception
      * @internal
      */
     private function shouldAddToQuery(string $dbFieldSpec): bool
     {
-        try {
-            [$serviceName] = ClassInfo::parse_class_spec($dbFieldSpec);
-            if (array_key_exists($serviceName, DataQuery::$shouldAddToQueryCache)) {
-                return DataQuery::$shouldAddToQueryCache[$serviceName];
-            }
-
-            $class = Injector::inst()->getServiceSpec($serviceName)['class'] ?? $serviceName;
-            $method = new ReflectionMethod($class, 'addToQuery');
-            if ($method->getDeclaringClass()->getName() === DBField::class) {
-                return DataQuery::$shouldAddToQueryCache[$serviceName] = false;
-            }
-        } catch (Exception) {
-            return true;
+        [$serviceName] = ClassInfo::parse_class_spec($dbFieldSpec);
+        if (array_key_exists($serviceName, DataQuery::$shouldAddToQueryCache)) {
+            return DataQuery::$shouldAddToQueryCache[$serviceName];
         }
 
-        return DataQuery::$shouldAddToQueryCache[$serviceName] = true;
+        $class = Injector::inst()->getServiceSpec($serviceName)['class'] ?? $serviceName;
+        $method = new ReflectionMethod($class, 'addToQuery');
+        $shouldAddToQuery = $method->getDeclaringClass()->getName() !== DBField::class;
+        DataQuery::$shouldAddToQueryCache[$serviceName] = $shouldAddToQuery;
+
+        return DataQuery::$shouldAddToQueryCache[$serviceName];
     }
 
     /**

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -2,17 +2,20 @@
 
 namespace SilverStripe\ORM;
 
+use Exception;
+use InvalidArgumentException;
+use ReflectionMethod;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\Connect\Query;
-use SilverStripe\ORM\Queries\SQLConditionGroup;
-use SilverStripe\ORM\Queries\SQLSelect;
-use InvalidArgumentException;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Resettable;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\Connect\Query;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\Queries\SQLConditionGroup;
+use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Security\RandomGenerator;
 
 /**
@@ -75,6 +78,13 @@ class DataQuery implements Resettable
     protected $querySubclasses = true;
 
     protected $filterByClassName = true;
+
+    /**
+     * A cache of database field specs and whether they implement an addToQuery() method
+     * @see DataQuery::shouldAddToQuery()
+     * @internal
+     */
+    private static array $shouldAddToQueryCache = [];
 
     /**
      * Whether the query result should be cached or not
@@ -697,18 +707,50 @@ class DataQuery implements Resettable
                 } else {
                     $query->selectField($quotedField, $k);
                 }
-                $dbO = Injector::inst()->create($v, $k);
-                $dbO->setTable($tableName);
-                $dbO->addToQuery($query);
+
+                if ($this->shouldAddToQuery($v)) {
+                    $dbO = Injector::inst()->create($v, $k);
+                    $dbO->setTable($tableName);
+                    $dbO->addToQuery($query);
+                }
             }
         }
         foreach ($compositeFields as $k => $v) {
-            if ((is_null($columns) || in_array($k, $columns ?? [])) && $v) {
+            if ((is_null($columns) || in_array($k, $columns ?? [])) && $v && $this->shouldAddToQuery($v)) {
                 $dbO = Injector::inst()->create($v, $k);
                 $dbO->setTable($tableName);
                 $dbO->addToQuery($query);
             }
         }
+    }
+
+    /**
+     * This method determines whether a subclass of DBField has overridden the DBField::addToQuery() method to
+     * implement custom logic. This allows selectColumnsFromTable() to skip the relatively expensive step of
+     * building singleton objects to call the method if it will have no effect
+     *
+     * @param string $dbFieldSpec A string like "Varchar(255)"
+     * @return bool
+     * @internal
+     */
+    private function shouldAddToQuery(string $dbFieldSpec): bool
+    {
+        try {
+            [$serviceName] = ClassInfo::parse_class_spec($dbFieldSpec);
+            if (array_key_exists($serviceName, DataQuery::$shouldAddToQueryCache)) {
+                return DataQuery::$shouldAddToQueryCache[$serviceName];
+            }
+
+            $class = Injector::inst()->getServiceSpec($serviceName)['class'] ?? $serviceName;
+            $method = new ReflectionMethod($class, 'addToQuery');
+            if ($method->getDeclaringClass()->getName() === DBField::class) {
+                return DataQuery::$shouldAddToQueryCache[$serviceName] = false;
+            }
+        } catch (Exception) {
+            return true;
+        }
+
+        return DataQuery::$shouldAddToQueryCache[$serviceName] = true;
     }
 
     /**


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
This adds in-memory caching for two specific methods that were notably slow when profiling with XHProf. I’ll post some benchmarks in a comment below, but generally the CPU time saving scales based on the number of SELECT queries a given request is making.

There are probably many other places in framework that could see small benefits from in-memory caching like this, and while we probably don’t want to over-use this kind of pattern I think the benefits in these cases outweigh the code smell.

## Manual testing steps
With DDEV it’s a case of `ddev xhprof enable`, run the request a few times, visit `https://mysite.ddev.site/xhprof` and view results.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11932

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
