### PR TITLE
FIX Correctly set/remove container fieldlist

### DIFF
--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -300,6 +300,7 @@ class FieldList extends ArrayList
             }
 
             if (($childName == $fieldName) && (!$dataFieldOnly || $child->hasData())) {
+                $child->setContainerFieldList(null);
                 array_splice($this->items, $i ?? 0, 1);
                 break;
             } elseif ($child instanceof CompositeField) {
@@ -326,6 +327,8 @@ class FieldList extends ArrayList
         foreach ($this as $i => $field) {
             if ($field->getName() == $fieldName && (!$dataFieldOnly || $field->hasData())) {
                 $this->items[$i] = $newField;
+                $newField->setContainerFieldList($this);
+                $field->setContainerFieldList(null);
                 return true;
             } elseif ($field instanceof CompositeField) {
                 if ($field->replaceField($fieldName, $newField)) {
@@ -495,12 +498,12 @@ class FieldList extends ArrayList
     public function insertBefore(string $name, FormField $item, bool $appendIfMissing = true): ?FormField
     {
         $this->onBeforeInsert($item);
-        $item->setContainerFieldList($this);
 
         $i = 0;
         foreach ($this as $child) {
             if ($name == $child->getName() || $name == $child->id) {
                 array_splice($this->items, $i ?? 0, 0, [$item]);
+                $item->setContainerFieldList($this);
                 return $item;
             } elseif ($child instanceof CompositeField) {
                 $ret = $child->insertBefore($name, $item, false);
@@ -527,12 +530,12 @@ class FieldList extends ArrayList
     public function insertAfter(string $name, FormField $item, bool $appendIfMissing = true): ?FormField
     {
         $this->onBeforeInsert($item);
-        $item->setContainerFieldList($this);
 
         $i = 0;
         foreach ($this as $child) {
             if ($name == $child->getName() || $name == $child->id) {
                 array_splice($this->items, $i+1, 0, [$item]);
+                $item->setContainerFieldList($this);
                 return $item;
             } elseif ($child instanceof CompositeField) {
                 $ret = $child->insertAfter($name, $item, false);
@@ -563,6 +566,20 @@ class FieldList extends ArrayList
         $item->setContainerFieldList($this);
 
         return parent::push($item);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return FormField|null
+     */
+    public function shift()
+    {
+        $removedItem = parent::shift();
+        if ($removedItem) {
+            $removedItem->setContainerFieldList(null);
+        }
+        return $removedItem;
     }
 
     /**

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -161,7 +161,7 @@ class FormField extends RequestHandler implements FieldValidationInterface
     /**
      * Stores a reference to the FieldList that contains this object.
      *
-     * @var FieldList
+     * @var null|FieldList
      */
     protected $containerFieldList;
 
@@ -1316,7 +1316,7 @@ class FormField extends RequestHandler implements FieldValidationInterface
     /**
      * Set the FieldList that contains this field.
      *
-     * @param FieldList $containerFieldList
+     * @param null|FieldList $containerFieldList
      * @return $this
      */
     public function setContainerFieldList($containerFieldList)
@@ -1328,7 +1328,7 @@ class FormField extends RequestHandler implements FieldValidationInterface
     /**
      * Get the FieldList that contains this field.
      *
-     * @return FieldList
+     * @return null|FieldList
      */
     public function getContainerFieldList()
     {

--- a/tests/php/Forms/FieldListTest.php
+++ b/tests/php/Forms/FieldListTest.php
@@ -1209,4 +1209,85 @@ class FieldListTest extends SapphireTest
         $fieldlist->setContainerField(null);
         $this->assertNull($fieldlist->getContainerField());
     }
+
+    /**
+     * When adding a field to a FieldList, the container fieldlist should always be set.
+     * This is true regardless of how it gets added.
+     */
+    public function testSettingContainerFieldList(): void
+    {
+        $fieldList = new FieldList();
+        $fieldList->add(new TabSet('Root'));
+        $expected = $fieldList;
+
+        // add()
+        $field = new TextField('add');
+        $fieldList->add($field);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: add()');
+
+        // push()
+        $field = new TextField('push');
+        $fieldList->push($field);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: push()');
+
+        // unshift()
+        $field = new TextField('unshift');
+        $fieldList->unshift($field);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: unshift()');
+
+        // insertBefore()
+        $field = new TextField('insertBeforeA');
+        $fieldList->add(new TextField('insertBeforeB'));
+        $fieldList->insertBefore('insertBeforeB', $field);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: insertBefore()');
+
+        // insertAfter()
+        $field = new TextField('insertAfterA');
+        $fieldList->add(new TextField('insertAfterB'));
+        $fieldList->insertAfter('insertAfterB', $field);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: insertAfter()');
+
+        // replaceField()
+        $oldField = new TextField('replaceField');
+        $fieldList->add($oldField);
+        $field = new TextField('replaceField');
+        $fieldList->replaceField('replaceField', $field);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: replaceField()');
+        $this->assertNull($oldField->getContainerFieldList(), 'replaceField() should reset field list for removed field');
+
+        // addFieldToTab()
+        $field = new TextField('addFieldToTab');
+        $fieldList->addFieldToTab('Root.Main', $field);
+        $expected = $fieldList->findTab('Root.Main')->FieldList();
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: addFieldToTab()');
+
+        // addFieldsToTab()
+        $field = new TextField('addFieldsToTab');
+        $fieldList->addFieldsToTab('Root.Main', [$field]);
+        $this->assertSame($expected, $field->getContainerFieldList(), 'method called: addFieldsToTab()');
+
+        // shift()
+        $field = new TextField('shift');
+        $fieldList->unshift($field);
+        $fieldList->shift();
+        $this->assertNull($field->getContainerFieldList(), 'shift() should reset field list for removed field');
+
+        // removeFieldFromTab()
+        $field = new TextField('removeFieldFromTab');
+        $fieldList->addFieldToTab('Root.Main', $field);
+        $fieldList->removeFieldFromTab('Root.Main', 'removeFieldFromTab');
+        $this->assertNull($field->getContainerFieldList(), 'removeFieldFromTab() should reset field list for removed field');
+
+        // removeFieldsFromTab()
+        $field = new TextField('removeFieldsFromTab');
+        $fieldList->addFieldToTab('Root.Main', $field);
+        $fieldList->removeFieldsFromTab('Root.Main', ['removeFieldsFromTab']);
+        $this->assertNull($field->getContainerFieldList(), 'removeFieldsFromTab() should reset field list for removed field');
+
+        // removeByName()
+        $field = new TextField('removeByName');
+        $fieldList->add($field);
+        $fieldList->removeByName('removeByName');
+        $this->assertNull($field->getContainerFieldList(), 'removeByName() should reset field list for removed field');
+    }
 }


### PR DESCRIPTION
When adding a field to a FieldList, the containerFieldList property should be set.
When removing the field, it should get reset to null.

Turns out there were quite a few more cases of this not being done than just the one in the issue.

## Kitchen sink CI
- https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/21267926226
Failing elemental behat test is existing

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11937