### PR TITLE
ENH Don't create unnecessary singletons when checking if database is ready

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -886,10 +886,6 @@ class DataObjectSchema
                 return false;
             }
 
-            // Extensions aren't applied until a class is instantiated for
-            // the first time, so create a singleton to ensure extensions are applied.
-            singleton($required);
-
             // if any of the tables haven't had columns added yet
             $dbFields = DB::field_list($table);
             if (empty($dbFields)) {


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
`DataObjectSchema::tablesAreReadyForClass()` creates a singleton instance of every subclass of the class given to it. For example if a site has 20 page types, `tablesAreReadyForClass(SiteTree::class)` will create 20 singleton objects to check if all the tables are ready.

I don’t believe the singleton creation is actually necessary to figure this out. It was “introduced” here as part of https://github.com/silverstripe/silverstripe-framework/pull/11784, but has existed for years from when it was in `Security::database_is_ready()`. The comment suggests that it’s important that extensions are applied, but I think this is from the old `extraStatics()` method that used to exist in extensions - now that’s gone, this can all be figured out from config without creating the objects + applying the extensions.

Quick before/after on a project with 8 page types (including SiteTree itself):

<img width="541" height="132" alt="Screenshot 2026-01-23 at 16 13 46" src="https://github.com/user-attachments/assets/bc2d10ad-ec0f-4543-a81f-0d20d4e07f4d" />
<img width="544" height="136" alt="Screenshot 2026-01-23 at 16 13 50" src="https://github.com/user-attachments/assets/3294b204-bac9-4daf-a04a-9b379bc27a2f" />

There’s a relatively small CPU saving, but a more significant memory saving. Naturally the more page types, the bigger the difference this would be.

There are _probably_ other improvements that could be made (do we really need to loop over every subclass and query the table to check the fields match on every request?) but this is the lowest hanging fruit for now

## Manual testing steps
XHProf before/after!

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11939

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
