### PR TITLE
Fix: Rename the country "Turkey" to "Republic of Türkiye"

### DIFF
--- a/src/i18n/Data/Intl/IntlLocales.php
+++ b/src/i18n/Data/Intl/IntlLocales.php
@@ -1336,7 +1336,7 @@ class IntlLocales implements Locales, Resettable
         'tm' => 'Turkmenistan',
         'tn' => 'Tunisia',
         'to' => 'Tonga',
-        'tr' => 'Turkey',
+        'tr' => 'Republic of Türkiye',
         'tt' => 'Trinidad and Tobago',
         'tv' => 'Tuvalu',
         'tw' => 'Taiwan',


### PR DESCRIPTION
## Description
Fixes the name of the country "Turkey" to "Republic of Türkiye", according to the resolution of the UN from May 26, 2022.

## Issues
- #11948

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
