### PR TITLE
FIX Exclude password strength endpoint from RateLimitMiddleware

### DIFF
--- a/_config/requestprocessors.yml
+++ b/_config/requestprocessors.yml
@@ -24,6 +24,8 @@ SilverStripe\Core\Injector\Injector:
       ExtraKey: 'Security'
       MaxAttempts: 10
       Decay: 1
+      ExcludedURLPatterns:
+        - '#^Security/changepassword/ChangePasswordForm/field/Password/strength$#'
   RateLimitedSecurityController:
     class: SilverStripe\Control\Middleware\RequestHandlerMiddlewareAdapter
     properties:

--- a/src/Control/Middleware/RateLimitMiddleware.php
+++ b/src/Control/Middleware/RateLimitMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Control\Middleware;
 
+use InvalidArgumentException;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Cache\RateLimiter;
@@ -10,7 +11,6 @@ use SilverStripe\Security\Security;
 
 class RateLimitMiddleware implements HTTPMiddleware
 {
-
     /**
      * @var string Optional extra data to add to request key generation
      */
@@ -32,6 +32,13 @@ class RateLimitMiddleware implements HTTPMiddleware
     private $rateLimiter;
 
     /**
+     * URL regex patterns to bypass rate limiting for this instance.
+     *
+     * @var string[]
+     */
+    private array $excludedUrlPatterns = [];
+
+    /**
      * @param HTTPRequest $request
      * @param callable $delegate
      * @return HTTPResponse
@@ -45,7 +52,9 @@ class RateLimitMiddleware implements HTTPMiddleware
                 $this->getDecay()
             );
         }
-        if ($limiter->canAccess()) {
+        if ($this->shouldBypassRateLimit($request)) {
+            $response = $delegate($request);
+        } elseif ($limiter->canAccess()) {
             $limiter->hit();
             $response = $delegate($request);
         } else {
@@ -164,5 +173,49 @@ class RateLimitMiddleware implements HTTPMiddleware
     public function getRateLimiter()
     {
         return $this->rateLimiter;
+    }
+
+    /**
+     * Set the excluded URL regex patterns which will bypass rate limiting.
+     * @param string[] $patterns
+     * @return $this
+     */
+    public function setExcludedURLPatterns(array $patterns): static
+    {
+        foreach ($patterns as $pattern) {
+            // The @ error suppression operator is used to check for invalid regex without PHP warnings
+            // We're explicitly testing for regex errors in RateLimitMiddlewareTest.php
+            if (@preg_match($pattern, '') === false) {
+                throw new InvalidArgumentException(sprintf(
+                    'RateLimitMiddleware.ExcludedURLPatterns contains an invalid regex pattern: %s',
+                    $pattern
+                ));
+            }
+        }
+        $this->excludedUrlPatterns = $patterns;
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludedURLPatterns(): array
+    {
+        return $this->excludedUrlPatterns;
+    }
+
+    private function shouldBypassRateLimit(HTTPRequest $request): bool
+    {
+        $patterns = $this->getExcludedURLPatterns();
+        if (!$patterns) {
+            return false;
+        }
+        $url = $request->getURL();
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $url) === 1) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tests/php/Control/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/php/Control/Middleware/RateLimitMiddlewareTest.php
@@ -2,8 +2,12 @@
 
 namespace SilverStripe\Control\Tests\Middleware;
 
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Control\Middleware\RateLimitMiddleware;
 use SilverStripe\Control\Middleware\RequestHandlerMiddlewareAdapter;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Tests\Middleware\Control\TestController;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
@@ -63,5 +67,90 @@ class RateLimitMiddlewareTest extends FunctionalTest
         $this->assertEquals(429, $response->getStatusCode());
         $this->assertEquals(60, $response->getHeader('retry-after'));
         $this->assertNotEquals('Success', $response->getBody());
+    }
+
+    public function testSecurityRateLimitMiddlewareUsesConfiguredExclusion(): void
+    {
+        $securityMiddleware = Injector::inst()->get('SecurityRateLimitMiddleware');
+        $this->assertInstanceOf(RateLimitMiddleware::class, $securityMiddleware);
+        $this->assertSame(
+            ['#^Security/changepassword/ChangePasswordForm/field/Password/strength$#'],
+            $securityMiddleware->getExcludedURLPatterns()
+        );
+    }
+
+    public static function provideShouldBypassRateLimit(): array
+    {
+        return [
+            'matching POST URL bypasses rate limit' => [
+                'httpMethod' => 'POST',
+                'url' => 'Security/changepassword/ChangePasswordForm/field/Password/strength',
+                'patterns' => ['#^Security/changepassword/ChangePasswordForm/field/Password/strength$#'],
+                'expectedBypass' => true,
+            ],
+            'custom patterns, custom URL bypasses' => [
+                'httpMethod' => 'POST',
+                'url' => 'custom/endpoint',
+                'patterns' => ['#^custom/endpoint$#'],
+                'expectedBypass' => true,
+            ],
+            'non-matching POST URL is rate limited' => [
+                'httpMethod' => 'POST',
+                'url' => 'custom/strength',
+                'patterns' => ['#^custom/strength-extra$#'],
+                'expectedBypass' => false,
+            ],
+            'matching GET URL bypasses rate limit' => [
+                'httpMethod' => 'GET',
+                'url' => 'custom/strength',
+                'patterns' => ['#^custom/strength$#'],
+                'expectedBypass' => true,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideShouldBypassRateLimit')]
+    public function testShouldBypassRateLimit(
+        string $httpMethod,
+        string $url,
+        array $patterns,
+        bool $expectedBypass
+    ): void {
+        $middleware = $this->createMiddleware($httpMethod . '-' . $url);
+        $middleware->setExcludedURLPatterns($patterns);
+        $request = new HTTPRequest($httpMethod, $url);
+        $response = $this->processRequest($middleware, $request);
+        $this->assertFalse($response->isError());
+        $response = $this->processRequest($middleware, $request);
+        if ($expectedBypass) {
+            $this->assertFalse($response->isError());
+        } else {
+            $this->assertTrue($response->isError());
+            $this->assertEquals(429, $response->getStatusCode());
+        }
+    }
+
+    private function createMiddleware(string $extraKey): RateLimitMiddleware
+    {
+        $middleware = new RateLimitMiddleware();
+        $middleware->setExtraKey($extraKey);
+        $middleware->setMaxAttempts(1);
+        $middleware->setDecay(1);
+        return $middleware;
+    }
+
+    private function processRequest(RateLimitMiddleware $middleware, HTTPRequest $request): HTTPResponse
+    {
+        return $middleware->process($request, function (HTTPRequest $request): HTTPResponse {
+            return HTTPResponse::create('Success', 200);
+        });
+    }
+
+    public function testSetExcludedURLPatternsThrowsExceptionForInvalidRegex(): void
+    {
+        $middleware = new RateLimitMiddleware();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('RateLimitMiddleware.ExcludedURLPatterns contains an invalid regex pattern: #[invalid(#');
+        $middleware->setExcludedURLPatterns(['#[invalid(#']);
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11947

Note this has new added new API though is targetting a patch release. Let me know if this is an issue and I'll retarget to `6`. The other option is to make it non-configurable and hardcode in 'strength' in somewhere, but that's a solution we'll need to reimplement for `6` and then remove the hardcoding, so I'd prefer not to do that.

This issue only seems to affect the 'forgot password flow outside of the cms', not the 'change my password in the CMS' flow

This was probably initially missed because [framework routes.yml](https://github.com/silverstripe/silverstripe-framework/blob/6/_config/routes.yml#L22) will exclude RateLimiting on the `/Security/*` endpoints for `dev` environments. This isn't great though probably a good thing for for core DX, so we should probably keep this as is

The original issue has the following options, I'll explain why they weren't implemented:

> Exclude strength endpoint from rate limiting

This was implemented

> Move strength checking to client-side - Use a JS library like zxcvbn for real-time feedback without server round-trips

We use symfony for password validation, server round trip is required. We do not want different logic on client side and server side for validation

> Debounce the AJAX requests more aggressively

It's already debounced a fair bit, increasing the debounce will negatively effect UX

> Increase default rate limit - The current default of 10/min is too low for normal Security controller usage

I'm not sure it is too low. And it won't fix root issue.
