### PR TITLE
DEP Allow multiple versions of sebastian/diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "nikic/php-parser": "^5.3",
         "psr/container": "^2.0",
         "psr/http-message": "^2.0",
-        "sebastian/diff": "^6.0",
+        "sebastian/diff": "^6|^7|^8",
         "sensiolabs/ansi-to-html": "^1.2",
         "silverstripe/config": "^3",
         "silverstripe/assets": "^3",

--- a/tests/php/View/Parsers/HtmlDiffTest.php
+++ b/tests/php/View/Parsers/HtmlDiffTest.php
@@ -69,6 +69,36 @@ class HtmlDiffTest extends SapphireTest
         $this->assertSame($expected, $differ->diffToArray($from, $to));
     }
 
+    public static function provideLineEndingCompatibility(): array
+    {
+        return [
+            'line endings normalized without escaping' => [
+                'from' => "<p>Line one\r\nLine two</p>",
+                'to' => "<p>Line one\nLine two</p>",
+                'escape' => false,
+                'expected' => '<p>Line one Line two</p>',
+            ],
+            'line endings normalized with escaped html' => [
+                'from' => "<p>Line one\r\nLine two</p>",
+                'to' => "<p>Line one\nLine two</p>",
+                'escape' => true,
+                'expected' => '&lt;p&gt;Line one Line two&lt;/p&gt;',
+            ],
+        ];
+    }
+
+    /**
+     * Verifies that different line ending styles (CRLF vs LF) are normalized during comparison,
+     * ensuring the algorithm doesn't treat them as content changes. Tests both with and without
+     * HTML escaping to ensure line ending normalization is consistent regardless of escaping mode.
+     */
+    #[DataProvider('provideLineEndingCompatibility')]
+    public function testLineEndingCompatibility(string $from, string $to, bool $escape, string $expected): void
+    {
+        $diff = HtmlDiff::compareHtml($from, $to, $escape);
+        $this->assertSame($this->removeWhiteSpace($expected), $this->removeWhiteSpace($diff));
+    }
+
     public static function provideCompareHtml(): array
     {
         return [


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11958

Targeting next minor as it's a dep change

This dep is not a [fixed dependency](https://docs.silverstripe.org/en/6/project_governance/fixed_dependencies/)

Should install the following:
- PHPUnit ^11.3 sebastian/diff 6.0.2
- PHPUnit ^12.0 sebastian/diff 7.0.0
- PHPUnit ^13.0 sebastian/diff 8.0.0


IDK - I'm in 2 minds about this one. Looks like there is difference between 6.0.2 and 7.0.0 - https://github.com/sebastianbergmann/diff/compare/6.0.2..7.0.0 - I'm inclined to not merge this