### PR TITLE
Add config to disable base tag output

### DIFF
--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Control\Director;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use InvalidArgumentException;
@@ -60,6 +61,13 @@ class SSViewer
      * Set if hash links should be rewritten
      */
     private static bool $rewrite_hash_links = true;
+
+    /**
+     * Whether the `<% base_tag %>` template variable should output a `<base>` tag.
+     * Set to false to disable base tag output.
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it
+     */
+    private static bool $enable_base_tag = true;
 
     /**
      * Overridden value of $themes config
@@ -382,9 +390,16 @@ class SSViewer
      * It will be closed on an XHTML document, and unclosed on an HTML document.
      *
      * @param bool $isXhtml Whether the DOCTYPE is xhtml or not.
+     * @deprecated 6.2.0 Will be removed without equivalent functionality to replace it
      */
     public static function getBaseTag(bool $isXhtml = false): string
     {
+        if (!static::config()->get('enable_base_tag')) {
+            return '';
+        }
+
+        Deprecation::noticeWithNoReplacment('6.2.0');
+
         // Base href should always have a trailing slash
         $base = rtrim(Director::absoluteBaseURL(), '/') . '/';
 

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\View\Tests;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
@@ -250,6 +251,23 @@ class SSViewerTest extends SapphireTest
             $result,
             'SSTemplateParser should only rewrite anchor hrefs'
         );
+    }
+
+    public function testGetBaseTag()
+    {
+        Director::config()->set('alternate_base_url', 'https://example.com/');
+
+        // Enabled should return a base tag
+        SSViewer::config()->set('enable_base_tag', true);
+        $this->assertSame('<base href="https://example.com/">', SSViewer::getBaseTag());
+
+        // XHTML mode should return a self-closing base tag
+        $this->assertSame('<base href="https://example.com/" />', SSViewer::getBaseTag(true));
+
+        // Disabled should return an empty string
+        SSViewer::config()->set('enable_base_tag', false);
+        $this->assertSame('', SSViewer::getBaseTag());
+        $this->assertSame('', SSViewer::getBaseTag(true));
     }
 
     private function assertEqualIgnoringWhitespace(string $a, string $b, string $message = ''): void


### PR DESCRIPTION
As discussed in #11961, enable_base_tag is introduced as a config option, true by default, but able to be disabled. Note that without silverstripe/silverstripe-admin#2112 this will break the CMS.

## Summary
- Adds `SSViewer.enable_base_tag` config option (default `true`)
- When set to `false`, `getBaseTag()` returns an empty string, allowing sites to operate without the `<base>` HTML tag

## Related PRs
- silverstripe/silverstripe-admin#2112

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11961