### PR TITLE
FIX Make renameField()/renameTable() transactional during schema updates

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -198,6 +198,16 @@ abstract class DBSchemaManager
                             $changes['alteredOptions'],
                             $advancedOptions
                         );
+                        // Process any queued field renames for this table
+                        if (!empty($changes['renamedFields'])) {
+                            foreach ($changes['renamedFields'] as $oldName => $newName) {
+                                $this->renameField($tableName, $oldName, $newName);
+                            }
+                        }
+                        break;
+
+                    case 'rename':
+                        $this->renameTable($tableName, $changes['newName']);
                         break;
                 }
             }
@@ -323,6 +333,33 @@ abstract class DBSchemaManager
     }
 
     /**
+     * Instruct the schema manager to record a field rename to later execute
+     *
+     * @param string $table Name of the table containing the field
+     * @param string $oldName Current name of the field
+     * @param string $newName New name for the field
+     */
+    public function transRenameField($table, $oldName, $newName)
+    {
+        $this->transInitTable($table);
+        $this->schemaUpdateTransaction[$table]['renamedFields'][$oldName] = $newName;
+    }
+
+    /**
+     * Instruct the schema manager to record a table rename to later execute
+     *
+     * @param string $oldTableName The current table name
+     * @param string $newTableName The new table name
+     */
+    public function transRenameTable($oldTableName, $newTableName)
+    {
+        $this->schemaUpdateTransaction[$oldTableName] = [
+            'command' => 'rename',
+            'newName' => $newTableName,
+        ];
+    }
+
+    /**
      * Handler for the other transXXX methods - mark the given table as being altered
      * if it doesn't already exist
      *
@@ -337,7 +374,8 @@ abstract class DBSchemaManager
                 'newIndexes' => [],
                 'alteredFields' => [],
                 'alteredIndexes' => [],
-                'alteredOptions' => ''
+                'alteredOptions' => '',
+                'renamedFields' => [],
             ];
         }
     }
@@ -479,7 +517,13 @@ abstract class DBSchemaManager
             $renameTo = $prefix . $suffix;
         }
         $renameFrom = $this->tableList[strtolower($table)];
-        $this->renameTable($renameFrom, $renameTo);
+        // Use transactional rename when inside a schemaUpdate() call,
+        // otherwise fall back to direct execution
+        if ($this->schemaUpdateTransaction !== null) {
+            $this->transRenameTable($renameFrom, $renameTo);
+        } else {
+            $this->renameTable($renameFrom, $renameTo);
+        }
         $this->alterationMessage("Table $table: renamed to $renameTo", "obsolete");
     }
 
@@ -844,6 +888,10 @@ abstract class DBSchemaManager
      */
     public function dontRequireField($table, $fieldName)
     {
+        // During a schema update, if the table doesn't exist yet there's nothing to rename
+        if ($this->schemaIsUpdating && !isset($this->tableList[strtolower($table)])) {
+            return;
+        }
         $fieldList = $this->fieldList($table);
         if (array_key_exists($fieldName, $fieldList ?? [])) {
             $suffix = '';
@@ -852,9 +900,16 @@ abstract class DBSchemaManager
                         ? ((int)$suffix + 1)
                         : 2;
             }
-            $this->renameField($table, $fieldName, "_obsolete_{$fieldName}$suffix");
+            $newName = "_obsolete_{$fieldName}$suffix";
+            // Use transactional rename when inside a schemaUpdate() call,
+            // otherwise fall back to direct execution
+            if ($this->schemaUpdateTransaction !== null) {
+                $this->transRenameField($table, $fieldName, $newName);
+            } else {
+                $this->renameField($table, $fieldName, $newName);
+            }
             $this->alterationMessage(
-                "Field $table.$fieldName: renamed to $table._obsolete_{$fieldName}$suffix",
+                "Field $table.$fieldName: renamed to $table.$newName",
                 "obsolete"
             );
         }

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -36,6 +36,43 @@ class DatabaseTest extends SapphireTest
         );
 
         static::resetDBSchema(true);
+
+        // Clean up _obsolete_ column left over from the direct call above
+        $schema->clearCachedFieldlist();
+        if (array_key_exists('_obsolete_MyField', $schema->fieldList('DatabaseTest_MyObject'))) {
+            DB::query('ALTER TABLE "DatabaseTest_MyObject" DROP COLUMN "_obsolete_MyField"');
+            $schema->clearCachedFieldlist();
+        }
+
+        // Transactional: dontRequireField inside schemaUpdate() on existing field
+        $this->assertArrayHasKey('MyField', $schema->fieldList('DatabaseTest_MyObject'));
+
+        DB::quiet();
+        $schema->schemaUpdate(function () use ($schema) {
+            $schema->dontRequireField('DatabaseTest_MyObject', 'MyField');
+        });
+
+        $schema->clearCachedFieldlist();
+        $fields = $schema->fieldList('DatabaseTest_MyObject');
+        $this->assertArrayNotHasKey(
+            'MyField',
+            $fields,
+            'Field is renamed inside schemaUpdate() transaction'
+        );
+        $this->assertArrayHasKey(
+            '_obsolete_MyField',
+            $fields,
+            'Field renamed to _obsolete_<fieldname> inside schemaUpdate() transaction'
+        );
+
+        static::resetDBSchema(true);
+
+        // Transactional: dontRequireField on non-existent table should silently skip
+        DB::quiet();
+        $schema->schemaUpdate(function () use ($schema) {
+            $schema->dontRequireField('NonExistent_Table', 'SomeField');
+        });
+        $this->assertTrue(true, 'dontRequireField on non-existent table does not error inside schemaUpdate()');
     }
 
     public function testRenameField()
@@ -58,6 +95,37 @@ class DatabaseTest extends SapphireTest
         );
 
         static::resetDBSchema(true);
+
+        // Transactional: dontRequireTable on non-existent table should silently skip
+        DB::quiet();
+        $schema->schemaUpdate(function () use ($schema) {
+            $schema->dontRequireTable('NonExistent_Table');
+        });
+        $this->assertTrue(true, 'dontRequireTable on non-existent table does not error inside schemaUpdate()');
+
+        // Transactional: dontRequireTable on existing table should rename it
+        DB::query(
+            'CREATE TABLE "DatabaseTest_Disposable"'
+            . ' ("ID" int not null auto_increment, primary key ("ID"))'
+        );
+        $this->assertTrue($schema->hasTable('DatabaseTest_Disposable'));
+
+        DB::quiet();
+        $schema->schemaUpdate(function () use ($schema) {
+            $schema->dontRequireTable('DatabaseTest_Disposable');
+        });
+
+        $this->assertFalse(
+            $schema->hasTable('DatabaseTest_Disposable'),
+            'Table is removed after transactional dontRequireTable()'
+        );
+        $this->assertTrue(
+            $schema->hasTable('_obsolete_DatabaseTest_Disposable'),
+            'Table is renamed to _obsolete_* after transactional dontRequireTable()'
+        );
+
+        // Clean up
+        DB::query('DROP TABLE IF EXISTS "_obsolete_DatabaseTest_Disposable"');
     }
 
     public function testMySQLCreateTableOptions()


### PR DESCRIPTION
## Description
Using dont_require_field to remove a previously added field has been too risky, as it throws an error on a fresh database. Now it will work.

This has been solved by adding `transRenameField()` and `transRenameTable()` that will defer the rename fields to run in the schema-update "transaction". dontRequireField uses these functions when called in a schema update operation.

## Manual testing steps

It's a bit edge-casey. We will create a custom DB field that adds an extra field, and then remove it with dont_require_field. Then we will delete the database and verify that dont_require_field still works.

Start with this Page.php

```php
<?php

namespace {

    use SilverStripe\ORM\FieldType\DBText;
    use SilverStripe\ORM\DB;
    use SilverStripe\CMS\Model\SiteTree;

    class DBCustomField extends DBText {

        public function requireField(): void
        {
            // Version one
            // DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
            // DB::require_field($this->tableName, $this->name . "_extra", $this->getFieldSpec());

            // Version two
            DB::require_field($this->tableName, $this->name, $this->getFieldSpec());
            DB::dont_require_field($this->tableName, $this->name . "_extra");
        }
    }

    class Page extends SiteTree
    {
        private static $db = [
            "CustomField" => "DBCustomField",
        ];

        private static $has_one = [];
    }
}
```

Run dev/build. The following Page table is created:

```
mysql> show create table Page;
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                                                                                                      |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Page  | CREATE TABLE `Page` (
  `ID` int NOT NULL AUTO_INCREMENT,
  `CustomField` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
  `CustomField_extra` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
  PRIMARY KEY (`ID`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Then amend the code above to version 2 and run dev/build. Verify that the extra field is dropped.

```
mysql> show create table Page;
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                                                                                                                |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Page  | CREATE TABLE `Page` (
  `ID` int NOT NULL AUTO_INCREMENT,
  `CustomField` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
  `_obsolete_CustomField_extra` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
  PRIMARY KEY (`ID`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

Finally, delete the Page table altogether and run dev/build. There is no error and the field is created without the obsolete one. Previously, this would have had a 'table-not-found' error.

```
mysql> show create table Page;
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                   |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Page  | CREATE TABLE `Page` (
  `ID` int NOT NULL AUTO_INCREMENT,
  `CustomField` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
  PRIMARY KEY (`ID`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

## Issues
 * Fixes #1376
 
## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
