### PR TITLE
FIX Only show DatetimeField format description for non-HTML5 inputs

### DIFF
--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -182,16 +182,18 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         $dateTimeFormat = $field->getDatetimeFormat();
         $locale = $field->getLocale();
 
-        // Set date formatting hints and example
-        $date = static::now()->Format($dateTimeFormat, $locale);
-        $field
-            ->setDescription(_t(
+        // Set date formatting hints and example when not using HTML5 inputs,
+        // as browsers handle format display natively for HTML5 datetime-local fields
+        $field->setAttribute('placeholder', $dateTimeFormat);
+        if (!$field->getHTML5()) {
+            $date = static::now()->Format($dateTimeFormat, $locale);
+            $field->setDescription(_t(
                 'SilverStripe\\Forms\\FormField.EXAMPLE',
                 'e.g. {format}',
                 'Example format',
                 ['format' => $date]
-            ))
-            ->setAttribute('placeholder', $dateTimeFormat);
+            ));
+        }
 
         return $field;
     }


### PR DESCRIPTION
When using HTML5 datetime-local inputs (the default), the scaffolded description shows an ISO 8601 format example that doesn't match what browsers actually display in their native date/time pickers.

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Before (note misleading date format):
<img width="1778" height="228" alt="Screenshot 2026-02-11 at 11 33 14@2x" src="https://github.com/user-attachments/assets/774d7fe8-9a08-4b1c-92d7-5e22cbd3e805" />

After:
<img width="1604" height="162" alt="Screenshot 2026-02-11 at 11 32 19@2x" src="https://github.com/user-attachments/assets/70eabc42-5a80-485b-a096-8bf93343690b" />

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
Verify display of a scaffolded `Datetimefield`, e.g.:
```php
use SilverStripe\CMS\Model\SiteTree;

class Page extends SiteTree
{
    private static $db = [
        'EventDate' => 'Datetime',
    ];
}
```
## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- Fixes #11867

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
