### PR TITLE
FIX Suppress deprecation notice for SSViewer.enable_base_tag

### DIFF
--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -394,7 +394,7 @@ class SSViewer
      */
     public static function getBaseTag(bool $isXhtml = false): string
     {
-        if (!static::config()->get('enable_base_tag')) {
+        if (!Deprecation::withSuppressedNotice(fn() => static::config()->get('enable_base_tag'))) {
             return '';
         }
 


### PR DESCRIPTION
When we try to get values for deprecated config, a deprecation notice gets emitted. If we can't avoid getting the config value for now, we need to suppress the notice.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11969