### PR TITLE
FIX ListboxField discarding mised-type values - CMS 6.1

### DIFF
--- a/src/Forms/ListboxField.php
+++ b/src/Forms/ListboxField.php
@@ -263,6 +263,7 @@ class ListboxField extends MultiSelectField
             $replaced = [];
             foreach ($value as $item) {
                 if (!is_array($item) && is_string($item)) {
+                    // Schema listbox values can be posted as JSON strings with a Value key.
                     $trimmed = trim($item);
                     if ($trimmed !== '') {
                         $firstChar = substr($trimmed, 0, 1);

--- a/tests/php/Forms/ListboxFieldTest.php
+++ b/tests/php/Forms/ListboxFieldTest.php
@@ -150,6 +150,13 @@ class ListboxFieldTest extends SapphireTest
                 'input' => '0',
                 'expected' => ['0'],
             ],
+            'schema-json-values' => [
+                'input' => [
+                    '{"Value":"123","Title":"String integer"}',
+                    '{"Value":"ABC123","Title":"Alpha-numeric string"}',
+                ],
+                'expected' => ['123', 'ABC123'],
+            ],
         ];
     }
 
@@ -169,6 +176,41 @@ class ListboxFieldTest extends SapphireTest
         $field->setValue($input);
         $field->saveInto($obj);
         $this->assertSame($expected, json_decode($obj->Choices, true));
+    }
+
+    public function testSaveIntoPreservesNumericStringFirstChoice(): void
+    {
+        $choices = [
+            '123' => 'Numeric string',
+            'ABC123' => 'Alpha-numeric string',
+        ];
+        $field = new ListboxField('Choices', 'Choices', $choices);
+        $obj = new TestObject();
+        $field->setValue(['123', 'ABC123']);
+        $field->saveInto($obj);
+        $this->assertSame(['123', 'ABC123'], json_decode($obj->Choices, true));
+    }
+
+    public static function provideGetValueArrayMixedTypeScenarios(): array
+    {
+        return [
+            'numeric-source-mixed-values' => [
+                'source' => [
+                    1 => 'One',
+                    2 => 'Two',
+                ],
+                'input' => ['1', 2, '2', 1],
+                'expected' => ['1', 2, '2', 1],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetValueArrayMixedTypeScenarios')]
+    public function testGetValueArrayPreservesMixedTypes(array $source, array $input, array $expected): void
+    {
+        $field = new ListboxField('Choices', 'Choices', $source);
+        $field->setValue($input);
+        $this->assertSame($expected, $field->getValueArray());
     }
 
     public function testSaveIntoManyManyRelation()


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11956

Tricky merge-up, lots of conflict, so redoing solution for CMS 6.1 (different PR from 5.4). ~Added some extra stuff to for edge cases~

- Adapt 5.4 solution for 6.1 to resolve ListboxField.php conflict while retaining CMS 6 logic
- ~Guard ListboxField getValueArray type coercion for mixed-type source values and handle zero scalar inputs~
- ~Tighten ListboxField schema value decoding to only accept Value or value payloads while preserving mixed-type selections~
- ~Add regression coverage for numeric-string-first choices and JSON schema values in ListboxFieldTest~

[CMS 5.4 PR](https://github.com/silverstripe/silverstripe-framework/pull/11971)

After merged assign back to Steve to handle the merge-up 