### PR TITLE
ENH Prefer X-Forwarded-Proto header

### DIFF
--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -130,7 +130,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @var array
      */
     private static $defaultVary = [
-        "X-Forwarded-Protocol" => true,
+        'X-Forwarded-Proto' => true,
     ];
 
     /**

--- a/src/Control/Middleware/TrustedProxyMiddleware.php
+++ b/src/Control/Middleware/TrustedProxyMiddleware.php
@@ -43,8 +43,8 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      * @var array
      */
     private $proxySchemeHeaders = [
-        'X-Forwarded-Protocol',
         'X-Forwarded-Proto',
+        'X-Forwarded-Protocol',
     ];
 
     /**

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -800,17 +800,59 @@ class DirectorTest extends SapphireTest
 
         // nothing available
         $headers = [
-            'HTTP_X_FORWARDED_PROTOCOL', 'HTTPS', 'SSL'
+            'HTTP_X_FORWARDED_PROTOCOL',
+            'HTTP_X_FORWARDED_PROTO',
+            'HTTPS',
+            'SSL',
         ];
         foreach ($headers as $header) {
             if (isset($_SERVER[$header])) {
-                unset($_SERVER['HTTP_X_FORWARDED_PROTOCOL']);
+                unset($_SERVER[$header]);
             }
         }
 
         $this->assertEquals(
             'no',
             Director::test('TestController/returnIsSSL')->getBody()
+        );
+
+        $this->assertEquals(
+            'yes',
+            Director::test(
+                'TestController/returnIsSSL',
+                null,
+                null,
+                null,
+                null,
+                ['X-Forwarded-Proto' => 'https']
+            )->getBody()
+        );
+
+        $this->assertEquals(
+            'no',
+            Director::test(
+                'TestController/returnIsSSL',
+                null,
+                null,
+                null,
+                null,
+                ['X-Forwarded-Proto' => 'http']
+            )->getBody()
+        );
+
+        $this->assertEquals(
+            'yes',
+            Director::test(
+                'TestController/returnIsSSL',
+                null,
+                null,
+                null,
+                null,
+                [
+                    'X-Forwarded-Proto' => 'https',
+                    'X-Forwarded-Protocol' => 'http',
+                ]
+            )->getBody()
         );
 
         $this->assertEquals(

--- a/tests/php/Control/HTTPTest.php
+++ b/tests/php/Control/HTTPTest.php
@@ -87,12 +87,12 @@ class HTTPTest extends FunctionalTest
         $response = new HTTPResponse($body, 200);
         HTTPCacheControlMiddleware::singleton()
             ->setMaxAge(30)
-            ->setVary('X-Requested-With, X-Forwarded-Protocol');
+            ->setVary('X-Requested-With, X-Forwarded-Proto');
         $this->addCacheHeaders($response);
 
         // Vary set properly
         $v = $response->getHeader('Vary');
-        $this->assertStringContainsString("X-Forwarded-Protocol", $v);
+        $this->assertStringContainsString("X-Forwarded-Proto", $v);
         $this->assertStringContainsString("X-Requested-With", $v);
         $this->assertStringNotContainsString("Cookie", $v);
         $this->assertStringNotContainsString("User-Agent", $v);

--- a/tests/php/Control/Middleware/HTTPCacheControlMiddlewareTest.php
+++ b/tests/php/Control/Middleware/HTTPCacheControlMiddlewareTest.php
@@ -18,6 +18,29 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         HTTPCacheControlMiddleware::reset();
     }
 
+    public function testDefaultVaryIsXForwardedProto()
+    {
+        $cc = HTTPCacheControlMiddleware::singleton();
+        $response = new HTTPResponse();
+        $cc->applyToResponse($response);
+        $vary = $response->getHeader('Vary');
+        $this->assertNotEmpty($vary);
+        $this->assertStringContainsString('X-Forwarded-Proto', $vary);
+        $this->assertStringNotContainsString('X-Forwarded-Protocol', $vary);
+    }
+
+    public function testDefaultVaryCanBeDisabledViaConfig()
+    {
+        HTTPCacheControlMiddleware::config()->set('defaultVary', []);
+        HTTPCacheControlMiddleware::reset();
+
+        $cc = HTTPCacheControlMiddleware::singleton();
+        $response = new HTTPResponse();
+        $cc->applyToResponse($response);
+
+        $this->assertEmpty($response->getHeader('Vary'));
+    }
+
     public function provideCacheStates()
     {
         return [


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11973

Will change the outgoing header to the standard `Vary: X-Forwarded-Proto` from the non-standard `Vary: X-Forwarded-Protocol`. We could change this behavior to simply not output either though since we could make the assumption that all sites use HTTPS and the outgoing header is not required.

For in-coming headers, will respect both `Vary: X-Forwarded-Protocol` and `Vary: X-Forwarded-Proto` to determine if HTTPS was being used though was terminated.

I've currently got this targeting CMS 5.4, though we may decide that we don't want to change this in a patch release and it may break existing setups that rely on the non-standard `X-Forwarded-Protocol` header, and instead directly people to a config based solution instead for existing versions, and target this PR to `6` instead.
