### PR TITLE
FIX Correct typos with codespell in code, comments and documentation

### DIFF
--- a/src/Cli/Command/NavigateCommand.php
+++ b/src/Cli/Command/NavigateCommand.php
@@ -25,7 +25,7 @@ class NavigateCommand extends Command
         $app = new HTTPApplication(Injector::inst()->get(Kernel::class));
         $request = CLIRequestBuilder::createFromInput($input);
 
-        // Handle request and output resonse body
+        // Handle request and output response body
         $response = $app->handle($request);
         $output->writeln($response->getBody() ?? '', OutputInterface::OUTPUT_RAW);
 

--- a/src/Cli/Sake.php
+++ b/src/Cli/Sake.php
@@ -127,7 +127,7 @@ class Sake extends Application
     public function all(?string $namespace = null): array
     {
         $commands = parent::all($namespace);
-        // If number of tasks is greater than the limit, hide them from the main comands list.
+        // If number of tasks is greater than the limit, hide them from the main commands list.
         $maxTasks = Sake::config()->get('max_tasks_to_display');
         if (!$this->ignoreTaskLimit && $maxTasks > 0 && $namespace === null) {
             $tasks = [];
@@ -281,9 +281,9 @@ class Sake extends Application
     {
         $command = new Command('flush');
         $command->setDescription('Flush the cache (or use the <info>--flush</info> flag with any command)');
-        $command->setCode(function (InputInterface $input, OutputInterface $ouput) {
+        $command->setCode(function (InputInterface $input, OutputInterface $output) {
             // Actual flushing happens in `run()` when booting the kernel, so there's nothing to do here.
-            $ouput->writeln('Cache flushed.');
+            $output->writeln('Cache flushed.');
             return Command::SUCCESS;
         });
         return $command;

--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -702,7 +702,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
             list($url, $querystring) = explode('?', $url, 2);
         }
 
-        // Normlise trailing slash
+        // Normalise trailing slash
         $shouldHaveTrailingSlash = Controller::config()->uninherited('add_trailing_slash');
         if ($shouldHaveTrailingSlash && !str_ends_with($url, '/')) {
             $url .= '/';

--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -306,7 +306,7 @@ class Director implements TemplateGlobalProvider
         Injector::inst()->registerService($request, HTTPRequest::class);
 
         // Check if primary database must be used based on request rules
-        // Note this check must happend before the rules are processed as
+        // Note this check must happened before the rules are processed as
         // $shiftOnSuccess param is passed as true in `$request->match($pattern, true)` later on in
         // this method, which modifies `$this->dirParts`, thus affecting `$request->match($rule)` directly below
         $primaryDbOnlyRules = Director::config()->uninherited('rule_patterns_must_use_primary_db');

--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -219,8 +219,8 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      */
     public function addVary($vary)
     {
-        $combied = $this->combineVary($this->getVary(), $vary);
-        $this->setVary($combied);
+        $combined = $this->combineVary($this->getVary(), $vary);
+        $this->setVary($combined);
         return $this;
     }
 

--- a/src/Control/SessionHandler/FileSessionHandler.php
+++ b/src/Control/SessionHandler/FileSessionHandler.php
@@ -327,7 +327,7 @@ class FileSessionHandler extends AbstractSessionHandler
     /**
      * Check if a session file is expired.
      *
-     * This method is necessary becuse garbage collection may not have run yet.
+     * This method is necessary because garbage collection may not have run yet.
      *
      * @throws RuntimeException if the modified time of the file can't be read
      */

--- a/src/Core/Convert.php
+++ b/src/Core/Convert.php
@@ -188,7 +188,7 @@ class Convert
 
     /**
      * Safely encodes a SQL symbolic identifier (or list of identifiers), such as a database,
-     * table, or column name. Supports encoding of multi identfiers separated by
+     * table, or column name. Supports encoding of multi identifiers separated by
      * a delimiter (e.g. ".")
      *
      * @param string|array $identifier The identifier to escape. E.g. 'SiteTree.Title' or list of identifiers

--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -198,7 +198,7 @@ class Environment
             return static::$env[$name];
         }
         // isset() is used for $_ENV and $_SERVER instead of array_key_exists() to fix a very strange issue that
-        // occured in CI running silverstripe/recipe-kitchen-sink where PHP would timeout due apparently due to an
+        // occurred in CI running silverstripe/recipe-kitchen-sink where PHP would timeout due apparently due to an
         // excessively high number of array method calls. isset() is not used for static::$env above because
         // values there may be null, and isset() will return false for null values
         // Symfony also uses isset() for reading $_ENV and $_SERVER values

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -965,7 +965,7 @@ class Injector implements ContainerInterface
     }
 
     /**
-     * Returns the service, or `null` if it doesnt' exist. See {@link get()} for main usage.
+     * Returns the service, or `null` if it doesn't exist. See {@link get()} for main usage.
      *
      * @template T of object
      * @param class-string<T>|string $name The name of the service to retrieve. If not a registered
@@ -1143,7 +1143,7 @@ class Injector implements ContainerInterface
         $hasBacticks = false;
         $allMissing = true;
         // $value must start and end with backticks, though there can be multiple
-        // things being subsituted within $value e.g. "`VAR_ONE`:`VAR_TWO`:`VAR_THREE`"
+        // things being substituted within $value e.g. "`VAR_ONE`:`VAR_TWO`:`VAR_THREE`"
         if (preg_match('/^`.+`$/', $value ?? '')) {
             $hasBacticks = true;
             preg_match_all('/`(?<name>[^`]+)`/', $value, $matches);
@@ -1161,7 +1161,7 @@ class Injector implements ContainerInterface
                 }
             }
         }
-        // silverstripe sometimes explictly expects a null value rather than just an empty string
+        // silverstripe sometimes explicitly expects a null value rather than just an empty string
         if ($hasBacticks && $allMissing && $value === '') {
             return null;
         }

--- a/src/Core/Validation/FieldValidation/FieldValidationTrait.php
+++ b/src/Core/Validation/FieldValidation/FieldValidationTrait.php
@@ -27,9 +27,9 @@ trait FieldValidationTrait
      * b) Will create a MyFieldValidator and pass the name, value, and pass additional args, where each null values
      *    will be passed as null, and non-null values will call a method on the field e.g. will pass null for the first
      *    additional arg and call $field->getSomething() to get a value for the second additional arg
-     *    Keys are used to speicify the arg name, which is done to prevents duplicate
+     *    Keys are used to specify the arg name, which is done to prevents duplicate
      *    args being add to config when a subclass defines the same FieldValidator as a parent class.
-     *    Note that keys are not named args, they are simply arbitary keys - though best practice is
+     *    Note that keys are not named args, they are simply arbitrary keys - though best practice is
      *    for the keys to match constructor argument names.
      * c) Will disable a previously set MyFieldValidator. This is useful to disable a FieldValidator that was set
      *    on a parent class

--- a/src/Core/Validation/ValidationException.php
+++ b/src/Core/Validation/ValidationException.php
@@ -22,7 +22,7 @@ class ValidationException extends Exception
     use Configurable;
 
     /**
-     * List of controllers to show additioanl info when not in CLI
+     * List of controllers to show additional info when not in CLI
      * Subclasses of these controllers will also show additional info
      */
     private static array $show_additional_info_non_cli_controllers = [

--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -32,7 +32,7 @@ class Deprecation
      * Must be configured outside of the config API, as deprecation API
      * must be available before this to avoid infinite loops.
      *
-     * This will be overriden by the SS_DEPRECATION_ENABLED environment variable if present
+     * This will be overridden by the SS_DEPRECATION_ENABLED environment variable if present
      *
      * @internal - Marked as internal so this and other private static's are not treated as config
      */
@@ -96,7 +96,7 @@ class Deprecation
      * Enable throwing deprecation warnings. By default, this excludes warnings for
      * deprecated code which is called by core Silverstripe modules.
      *
-     * This will be overriden by the SS_DEPRECATION_ENABLED environment variable if present.
+     * This will be overridden by the SS_DEPRECATION_ENABLED environment variable if present.
      *
      * @param bool $showNoReplacementNotices If true, deprecation warnings will also be thrown
      * for deprecated code which is called by core Silverstripe modules.
@@ -110,7 +110,7 @@ class Deprecation
     /**
      * Disable throwing deprecation warnings.
      *
-     * This will be overriden by the SS_DEPRECATION_ENABLED environment variable if present.
+     * This will be overridden by the SS_DEPRECATION_ENABLED environment variable if present.
      */
     public static function disable(): void
     {
@@ -262,7 +262,7 @@ class Deprecation
      * Determine whether deprecation warnings should be included in HTTP responses.
      * Does not affect logging.
      *
-     * This will be overriden by the SS_DEPRECATION_SHOW_HTTP environment variable if present.
+     * This will be overridden by the SS_DEPRECATION_SHOW_HTTP environment variable if present.
      */
     public static function setShouldShowForHttp(bool $value): void
     {
@@ -273,7 +273,7 @@ class Deprecation
      * Determine whether deprecation warnings should be included in CLI responses.
      * Does not affect logging.
      *
-     * This will be overriden by the SS_DEPRECATION_SHOW_CLI environment variable if present.
+     * This will be overridden by the SS_DEPRECATION_SHOW_CLI environment variable if present.
      */
     public static function setShouldShowForCli(bool $value): void
     {
@@ -425,7 +425,7 @@ class Deprecation
                 Deprecation::$userErrorMessageBuffer[$data['key']] = $data;
 
                 // Use a shutdown function rather than immediately calling user_error() so that notices
-                // do not interfere with setting session varibles i.e. headers already sent error
+                // do not interfere with setting session variables i.e. headers already sent error
                 // it also means the deprecation notices appear below all phpunit output in CI
                 // which is far nicer than having it spliced between phpunit output
                 if (!Deprecation::$haveSetShutdownFunction && Deprecation::isEnabled()) {

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -244,7 +244,7 @@ class TaskRunner extends Controller implements PermissionProvider
         return [
             'BUILDTASK_CAN_RUN' => [
                 'name' => _t(__CLASS__ . '.BUILDTASK_CAN_RUN_DESCRIPTION', 'Can view and execute all /dev/tasks'),
-                'help' => _t(__CLASS__ . '.BUILDTASK_CAN_RUN_HELP', 'Can view and execute all Build Tasks (/dev/tasks). This may still be overriden by individual task view permissions'),
+                'help' => _t(__CLASS__ . '.BUILDTASK_CAN_RUN_HELP', 'Can view and execute all Build Tasks (/dev/tasks). This may still be overridden by individual task view permissions'),
                 'category' => DevelopmentAdmin::permissionsCategory(),
                 'sort' => 70
             ],

--- a/src/Forms/DropdownField.php
+++ b/src/Forms/DropdownField.php
@@ -82,7 +82,7 @@ use SilverStripe\Model\ArrayData;
  *
  * @see CheckboxSetField for multiple selections through checkboxes instead.
  * @see ListboxField for a single <select> box (with single or multiple selections).
- * @see TreeDropdownField for a rich and customizeable UI that can visualize a tree of selectable elements
+ * @see TreeDropdownField for a rich and customizable UI that can visualize a tree of selectable elements
  */
 class DropdownField extends SingleSelectField
 {

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -141,7 +141,7 @@ class FieldList extends ArrayList
         // Recursively add managed fields.
         // Note that we explicitly don't cache these fields because the field manager
         // is allowed to swap out field implementations for the same named field
-        // inbetween calls to this method.
+        // between calls to this method.
         $addDataField = function (FormField $field) use (&$dataFields, &$addDataField) {
             if (!is_a($field, ChildFieldManager::class)) {
                 return;

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -723,8 +723,8 @@ class FormField extends RequestHandler implements FieldValidationInterface
      */
     public function setValue($value, $data = null)
     {
-        // Note that unlike setSubmittedValue(), we are explicity not casting blank strings to null here.
-        // This is because setValue() is used when programatically setting a value on a field
+        // Note that unlike setSubmittedValue(), we are explicitly not casting blank strings to null here.
+        // This is because setValue() is used when programmatically setting a value on a field
         // and we want to enforce type strictness
         $this->value = $value;
         return $this;

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -145,10 +145,10 @@ class GridField extends FormField
 
     /**
      * Intentionally not set to FormField::SCHEMA_DATA_TYPE_STRUCTURAL even though there is no corresponding
-     * react component because we want a hard exception thrown for devleopers to see rather than have
+     * react component because we want a hard exception thrown for developers to see rather than have
      * them wonder why the field is not rendering.
      *
-     * Marked as @interal to allow change in a minor release as a react GridField may be implemented in the future
+     * Marked as @internal to allow change in a minor release as a react GridField may be implemented in the future
      *
      * @internal
      */
@@ -555,7 +555,7 @@ class GridField extends FormField
                         $sudoModeTransformation = true;
                     }
                 } else {
-                    // explicity set to false to update state for AJAX requests that refresh the gridfield after activating sudo mode
+                    // explicitly set to false to update state for AJAX requests that refresh the gridfield after activating sudo mode
                     $this->setReadonly(false);
                 }
             }

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -180,7 +180,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             $summaryFields = array_keys($singleton->summaryFields());
             sort($searchableFields);
             sort($summaryFields);
-            // searchable_fields has been explictily defined i.e. searchableFields() is not falling back to summary_fields
+            // searchable_fields has been explicitly defined i.e. searchableFields() is not falling back to summary_fields
             if (!empty($searchableFields) && ($searchableFields !== $summaryFields)) {
                 return true;
             }

--- a/src/Forms/HTMLEditor/HTMLEditorAttributeRule.php
+++ b/src/Forms/HTMLEditor/HTMLEditorAttributeRule.php
@@ -8,7 +8,7 @@ use SilverStripe\Core\ArrayLib;
 
 /**
  * Rules used to define whether a given attribute or regex pattern of attributes is allowed in the content of an HTMLEditorField.
- * Each attribute rule is applied to a single HTMLEditorElementRule matching an element or a regex patter of elements.
+ * Each attribute rule is applied to a single HTMLEditorElementRule matching an element or a regex pattern of elements.
  */
 class HTMLEditorAttributeRule
 {
@@ -182,7 +182,7 @@ class HTMLEditorAttributeRule
     }
 
     /**
-     * Check wither the given attribute is allowed or not according to this rule.
+     * Check whether the given attribute is allowed or not according to this rule.
      *
      * Note that this method assumes this rule applies to the attribute - it does
      * not check the name of the attribute as part of its conditional logic.

--- a/src/Forms/HTMLEditor/HTMLEditorConfig.php
+++ b/src/Forms/HTMLEditor/HTMLEditorConfig.php
@@ -114,7 +114,7 @@ abstract class HTMLEditorConfig
     /**
      * Default set of rules to define which elements and attributes are allowed, and how to treat them.
      *
-     * Every element that is allowed in the HTML content must be expicitly allowed, either on its own
+     * Every element that is allowed in the HTML content must be explicitly allowed, either on its own
      * or as part of a pattern.
      * Element names or patterns are keys in the associative array. Patterns can use the following special characters:
      * - `*` Matches between zero and unlimited characters (equivalent to `.*` in regex).
@@ -133,7 +133,7 @@ abstract class HTMLEditorConfig
      * - `"padEmpty"`: Set to `true` to add a non-breaking space to elements which have no child nodes.
      * - `"removeIfEmpty"`: Set to `true` to remove elements which have no child nodes.
      * - `"removeIfNoAttributes"`: Set to `true` to remove elements which have no attributes.
-     * - `"convertTo"`: Set to the string name of a specific attrbiute this element should be converted to. For example
+     * - `"convertTo"`: Set to the string name of a specific attribute this element should be converted to. For example
      * convert `<b>` to `<strong>`.
      * - `"attributes"`: An associative array of attributes allowed on this element and rules for them.
      *
@@ -142,7 +142,7 @@ abstract class HTMLEditorConfig
      * Patterns work the same way for attribute rules as they do for element rules.
      *
      * Like with elements, an attribute can have `true` or an associative array to mark it as allowed,
-     * or it can be ommitted, or have a `false` or `null` value to disallow it.
+     * or it can be omitted, or have a `false` or `null` value to disallow it.
      *
      * The array of attribute rules is associative. The following can be included in the array:
      * - `"isRequired"`: Set to `true` to make this attribute mandatory. If the attribute is missing, the element will

--- a/src/Forms/ListboxField.php
+++ b/src/Forms/ListboxField.php
@@ -28,7 +28,7 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
  * @see DropdownField for a simple select field with a single element.
  * @see CheckboxSetField for multiple selections through checkboxes.
  * @see OptionsetField for single selections via radiobuttons.
- * @see TreeDropdownField for a rich and customizeable UI that can visualize a tree of selectable elements
+ * @see TreeDropdownField for a rich and customizable UI that can visualize a tree of selectable elements
  */
 class ListboxField extends MultiSelectField
 {

--- a/src/Forms/NumericField.php
+++ b/src/Forms/NumericField.php
@@ -229,7 +229,7 @@ class NumericField extends TextField
             // e.g. 1.00 will be cast to 1, 1.20 will be cast to 1
             $value = (int) $value;
         } else {
-            // Otherwise, cast to float. This will remove any trailing deciaml zeros.
+            // Otherwise, cast to float. This will remove any trailing decimal zeros.
             // e.g. 1.00 will be cast to 1, 1.20 will be cast to 1.2
             $value = (float) $value;
         }

--- a/src/Forms/OptionsetField.php
+++ b/src/Forms/OptionsetField.php
@@ -52,7 +52,7 @@ use SilverStripe\Model\ArrayData;
  *
  * @see CheckboxSetField for multiple selections through checkboxes instead.
  * @see DropdownField for a simple <select> field with a single element.
- * @see TreeDropdownField for a rich and customizeable UI that can visualize a tree of selectable elements
+ * @see TreeDropdownField for a rich and customizable UI that can visualize a tree of selectable elements
  */
 class OptionsetField extends SingleSelectField
 {

--- a/src/Forms/SelectField.php
+++ b/src/Forms/SelectField.php
@@ -128,7 +128,7 @@ abstract class SelectField extends FormField
     }
 
     /**
-     * Convert a submitted value, which should probalby always be a string, to the correct type
+     * Convert a submitted value, which should probably always be a string, to the correct type
      * Currently this will only convert string int to int
      */
     protected function castSubmittedValue(mixed $value): mixed

--- a/src/Forms/SudoModePasswordField.php
+++ b/src/Forms/SudoModePasswordField.php
@@ -57,7 +57,7 @@ class SudoModePasswordField extends PasswordField
      * Set whether the field should be collapsed when initially rendered
      *
      * When collapsed the rendered component will include a way to expand the field
-     * When not collapsed the rendered component will not be collapsable
+     * When not collapsed the rendered component will not be collapsible
      */
     public function setInitiallyCollapsed(bool $initiallyCollapsed): static
     {

--- a/src/Model/List/ArrayList.php
+++ b/src/Model/List/ArrayList.php
@@ -680,7 +680,7 @@ class ArrayList extends ModelData implements SS_List
         $hasNullFilter = false;
 
         foreach ($filters as $filterKey => $filterValue) {
-            // Check if we have any null filter values for backwards compatability, since nulls are treated specially
+            // Check if we have any null filter values for backwards compatibility, since nulls are treated specially
             // in the ExactMatchFilter
             if (is_array($filterValue)) {
                 foreach ($filterValue as $value) {

--- a/src/Model/List/SS_List.php
+++ b/src/Model/List/SS_List.php
@@ -37,7 +37,7 @@ interface SS_List extends ArrayAccess, Countable, IteratorAggregate
     /**
      * Removes an item from the list.
      *
-     * Note that a return type is not specified on the interface as different impelementations
+     * Note that a return type is not specified on the interface as different implementations
      * have different return types.
      */
     public function remove(mixed $item);

--- a/src/Model/ModelData.php
+++ b/src/Model/ModelData.php
@@ -482,7 +482,7 @@ class ModelData
             }
 
             // Return null early if there's no backing for this field
-            // i.e. no poperty, no method, etc - it just doesn't exist on this model.
+            // i.e. no property, no method, etc - it just doesn't exist on this model.
             if (!$hasObj && $value === null) {
                 return null;
             }

--- a/src/ORM/Connect/DBConnector.php
+++ b/src/ORM/Connect/DBConnector.php
@@ -208,7 +208,7 @@ abstract class DBConnector
      * connector. Note that this does not quote the value.
      *
      * @param string $value The value to be escaped
-     * @return string The appropritaely escaped string for value
+     * @return string The appropriately escaped string for value
      */
     abstract public function escapeString($value);
 

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -1011,7 +1011,7 @@ abstract class DBSchemaManager
     /*
      * This is a lookup table for data types.
      * For instance, Postgres uses 'INT', while MySQL uses 'UNSIGNED'
-     * So this is a DB-specific list of equivilents.
+     * So this is a DB-specific list of equivalents.
      *
      * @param string $type
      * @return string

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -378,7 +378,7 @@ abstract class Database
      * and the values are map containing 'command' and 'fields'.  Command should be 'insert' or 'update',
      * and fields should be a map of field names to field values, NOT including quotes.
      *
-     * The field values could also be in paramaterised format, such as
+     * The field values could also be in parameterised format, such as
      * array('MAX(?,?)' => array(42, 69)), allowing the use of raw SQL values such as
      * array('NOW()' => array()).
      *

--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -842,7 +842,7 @@ class DB
 
     /**
      * Get a random replica database configuration key from the available replica configurations
-     * The replica choosen will be used for the rest of the request, unless the primary connection
+     * The replica chosen will be used for the rest of the request, unless the primary connection
      * is forced
      */
     private static function getRandomReplicaConfigKey(): string

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -50,7 +50,7 @@ class DataList extends ModelData implements SS_List, Resettable
     use SearchFilterable;
 
     /**
-     * Whether to use placeholders for integer IDs on Primary and Foriegn keys during a WHERE IN query
+     * Whether to use placeholders for integer IDs on Primary and Foreign keys during a WHERE IN query
      * It is significantly faster to not use placeholders
      */
     private static bool $use_placeholders_for_integer_ids = false;
@@ -310,7 +310,7 @@ class DataList extends ModelData implements SS_List, Resettable
      *
      *
      * @param string|array|SQLConditionGroup $filter Predicate(s) to set, as escaped SQL statements or
-     * paramaterised queries
+     * parameterised queries
      * @return static<T>
      */
     public function where($filter)
@@ -332,7 +332,7 @@ class DataList extends ModelData implements SS_List, Resettable
      * won't expand multiple method arguments as SQLSelect does.
      *
      * @param string|array|SQLConditionGroup $filter Predicate(s) to set, as escaped SQL statements or
-     * paramaterised queries
+     * parameterised queries
      * @return static<T>
      */
     public function whereAny($filter)
@@ -491,7 +491,7 @@ class DataList extends ModelData implements SS_List, Resettable
         }
         // $columnName is a param that is passed by reference so is essentially as a return type
         // it will be returned in quoted SQL "TableName"."ColumnName" notation
-        // if it's equal to $col however it means that it WAS orginally raw sql, which is disallowed for sort()
+        // if it's equal to $col however it means that it WAS originally raw sql, which is disallowed for sort()
         //
         // applyRelation() will also throw an InvalidArgumentException if $column is not raw sql but
         // the Relation.FieldName is not a valid model relationship

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3944,7 +3944,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 // If the next part is a DBField, we've found the database-backed field.
                 break;
             } elseif ($component instanceof DataObject && $component->getRelationType($nextPart) !== null) {
-                // If it's a last part or only one elemnt of a relation, we don't have a database-backed field.
+                // If it's a last part or only one element of a relation, we don't have a database-backed field.
                 if (count($parts) === 1) {
                     return null;
                 }
@@ -4497,7 +4497,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
      * If true, the search phrase is split into individual terms, and checks all searchable fields for each search term.
      * If false, all fields are checked for the entire search phrase as a whole.
      *
-     * Note that splitting terms may cause unexpected resuls if using an ExactMatchFilter.
+     * Note that splitting terms may cause unexpected results if using an ExactMatchFilter.
      */
     private static bool $general_search_split_terms = true;
 

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -507,7 +507,7 @@ class DataQuery implements Resettable
      * Return this query's SQL
      *
      * @param array $parameters Out variable for parameters required for this query
-     * @return string The resulting SQL query (may be paramaterised)
+     * @return string The resulting SQL query (may be parameterised)
      */
     public function sql(&$parameters = [])
     {
@@ -847,7 +847,7 @@ class DataQuery implements Resettable
      * won't expand multiple arguments as SQLSelect does.
      *
      * @param string|array|SQLConditionGroup $filter Predicate(s) to set, as escaped SQL statements or
-     * paramaterised queries
+     * parameterised queries
      * @return $this
      */
     public function where($filter)
@@ -865,7 +865,7 @@ class DataQuery implements Resettable
      * won't expand multiple method arguments as SQLSelect does.
      *
      * @param string|array|SQLConditionGroup $filter Predicate(s) to set, as escaped SQL statements or
-     * paramaterised queries
+     * parameterised queries
      * @return $this
      */
     public function whereAny($filter)

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -398,7 +398,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
      */
     public function offsetSet(mixed $key, mixed $value): void
     {
-        // Throw exception for compatability with DataList
+        // Throw exception for compatibility with DataList
         throw new BadMethodCallException("Can't alter items in an EagerLoadedList using array-access");
     }
 
@@ -408,7 +408,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
      */
     public function offsetUnset(mixed $key): void
     {
-        // Throw exception for compatability with DataList
+        // Throw exception for compatibility with DataList
         throw new BadMethodCallException("Can't alter items in an EagerLoadedList using array-access");
     }
 
@@ -667,7 +667,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
      * object or array.
      *
      * @param string $key They key for the value to be extracted. Implied mixed type
-     * for compatability with DataList.
+     * for compatibility with DataList.
      */
     private function extractValue(array $row, $key): mixed
     {
@@ -835,7 +835,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
             }
         }
 
-        // If $columnName is equal to $col it means that it was orginally raw sql or otherwise invalid.
+        // If $columnName is equal to $col it means that it was originally raw sql or otherwise invalid.
         if ($columnName === $column) {
             throw new InvalidArgumentException("Invalid sort column $column");
         }
@@ -866,7 +866,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
             throw new InvalidArgumentException("\$offset can not be negative. $offset was provided.");
         }
 
-        // We don't actually apply the limit immediately, for compatability with the way it works in DataList
+        // We don't actually apply the limit immediately, for compatibility with the way it works in DataList
         $list = clone $this;
         $list->limitOffset = [$length, $offset];
         return $list;
@@ -942,7 +942,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
      * Find the extra field data for a single row of the relationship join
      * table for many_many relations, given the known child ID.
      *
-     * @param string $componentName The name of the component (unused, but kept for compatability with ManyManyList)
+     * @param string $componentName The name of the component (unused, but kept for compatibility with ManyManyList)
      * @param int|string $itemID The ID of the child for the relationship
      *
      * @return array Map of fieldName => fieldValue
@@ -955,7 +955,7 @@ class EagerLoadedList extends ModelData implements Relation, SS_List
             throw new BadMethodCallException('Cannot have extra fields on this list type');
         }
 
-        // Allow string IDs for compatability with ManyManyList
+        // Allow string IDs for compatibility with ManyManyList
         if (!is_numeric($itemID)) {
             throw new InvalidArgumentException('$itemID must be an integer or numeric string');
         }

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -58,9 +58,9 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     ];
 
     /**
-     * Flag idicating if this field is considered immutable
+     * Flag indicating if this field is considered immutable
      * when this is enabled setting the value of this field will return a new field instance
-     * instead updatin the old one
+     * instead updating the old one
      */
     protected bool $immutable = false;
 
@@ -198,7 +198,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     }
 
     /**
-     * Get the amount of time inbetween two datetimes.
+     * Get the amount of time between two datetimes.
      */
     public static function getTimeBetween(DBDateTime $from, DBDateTime $to): string
     {

--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -125,7 +125,7 @@ class DBText extends DBString
             return '';
         }
 
-        // If no $elipsis string is provided, use the default one.
+        // If no $ellipsis string is provided, use the default one.
         if ($add === false) {
             $add = $this->defaultEllipsis();
         }

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -132,7 +132,7 @@ class Hierarchy extends Extension
 
     /**
      * The default method called on the Hierarchy class to get children
-     * This can be overriden on classes that use the Hierarchy extension, though it should only be
+     * This can be overridden on classes that use the Hierarchy extension, though it should only be
      * defined on the base class that has the hierarchy extension applied to it. For instance:
      * - MyBaseClass has the Hierarchy extension applied
      * - MySubClass extends MyBaseClass

--- a/src/ORM/Queries/SQLAssignmentRow.php
+++ b/src/ORM/Queries/SQLAssignmentRow.php
@@ -41,7 +41,7 @@ class SQLAssignmentRow
 
     /**
      * Given a key / value pair, extract the predicate and any potential parameters
-     * in a format suitable for storing internally as a list of paramaterised conditions.
+     * in a format suitable for storing internally as a list of parameterised conditions.
      *
      * @param mixed $value Either a literal field value, or an array with
      * placeholder => parameter(s) as a pair

--- a/src/PolyExecution/PolyOutput.php
+++ b/src/PolyExecution/PolyOutput.php
@@ -24,7 +24,7 @@ class PolyOutput extends Output
 
     /** Use this if you want HTML markup in the output */
     public const FORMAT_HTML = 'Html';
-    /** Use this for outputing to a terminal, or for plain text output */
+    /** Use this for outputting to a terminal, or for plain text output */
     public const FORMAT_ANSI = 'Ansi';
 
     private string $outputFormat;

--- a/src/Security/BasicAuthMiddleware.php
+++ b/src/Security/BasicAuthMiddleware.php
@@ -94,7 +94,7 @@ class BasicAuthMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request
      * @return bool|string|array|null boolean value if enabled/disabled explicitly for this request,
      * or null if should fall back to config value. Can also provide an explicit string / array of permission
-     * codes to require for this requset.
+     * codes to require for this request.
      */
     protected function checkMatchingURL(HTTPRequest $request)
     {

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -113,7 +113,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      *
      * @param string|array $code Code of the permission to check (case-sensitive)
      * @param string $arg Optional argument (e.g. a permissions for a specific page)
-     * @param int|Member $member Optional member instance or ID. If set to NULL, the permssion
+     * @param int|Member $member Optional member instance or ID. If set to NULL, the permission
      *  will be checked for the current user
      * @param bool $strict Use "strict" checking (which means a permission
      *  will be granted if the key does not exist at all)?
@@ -310,7 +310,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
                         'GroupID' => $groupIDs,
                     ]);
 
-                    // Get permission codes from roles these groups are assigned to, exluding the denied list above.
+                    // Get permission codes from roles these groups are assigned to, excluding the denied list above.
                     $permissionRoleCodes = PermissionRoleCode::get()
                         ->filter(['GroupID' => $groupIDs])
                         ->excludeByList($denied, 'Code', 'Code')

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -5,7 +5,7 @@ namespace SilverStripe\View\Exception;
 use LogicException;
 
 /**
- * Exception that indicates a template was not found when attemping to use a template engine
+ * Exception that indicates a template was not found when attempting to use a template engine
  */
 class MissingTemplateException extends LogicException
 {

--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -339,7 +339,7 @@ class ShortcodeParser
                         $name = '';
                         $value = '';
                         $parts = array_values(array_filter($attr ?? []));
-                        //the first element in the array is the complete delcaration (`id=1`) - we don't need this
+                        //the first element in the array is the complete declaration (`id=1`) - we don't need this
                         array_shift($parts);
 
                         //the next two parts are what we care about (id and 1 from `id=1`)

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -56,7 +56,7 @@ class Requirements_Backend
      * Determine if relative urls in the combined files should be converted to absolute.
      *
      * By default combined files will be parsed for relative URLs to image/font assets and those
-     * URLs will be changed to absolute to accomodate the fact that the combined css is placed
+     * URLs will be changed to absolute to accommodate the fact that the combined css is placed
      * in a totally different folder than the source css files.
      *
      * Turn this off if you see some unexpected results.

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -40,7 +40,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
     /**
      * Attributes to add to the iframe when sandboxing
      * Note that the 'src' attribute cannot be set via config
-     * If a style attribute is set via config, width and height values will be overriden by
+     * If a style attribute is set via config, width and height values will be overridden by
      * any shortcode width and height arguments
      */
     private static array $sandboxed_iframe_attributes = [];


### PR DESCRIPTION
## Description
Fixes variable name typo causing undefined variable error:
- src/Cli/Sake.php: $ouput -> $output

Maybe above should be fixed on 6.0 and upmerged?

Corrects misspelled variable names for consistency:
- src/Control/Middleware/HTTPCacheControlMiddleware.php: $combied -> $combined

Also corrects numerous typos in PHPDoc comments and inline documentation across 47 files, including common misspellings like "overridden", "parameterised", "compatibility", "explicitly", "substituted", "occurred", etc.

Note: `protected $enviroment` vs `protected $environment` in BaseKernel is intentionally left unchanged to avoid breaking changes; it should be addressed in the next major release.

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
