### PR TITLE
FIX Director::hostName() returning null for bare hostnames

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -567,8 +567,8 @@ class Director implements TemplateGlobalProvider
      */
     public static function hostName(?HTTPRequest $request = null)
     {
-        $host = static::host($request);
-        return parse_url($host ?? '', PHP_URL_HOST) ?: null;
+        $host = parse_url(static::protocolAndHost($request), PHP_URL_HOST);
+        return is_string($host) && $host !== '' ? $host : null;
     }
 
     /**

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -270,6 +270,21 @@ class DirectorTest extends SapphireTest
         $this->assertEquals('9090', Director::port());
     }
 
+    public function testHostNameWithoutPort()
+    {
+        // Reproduces the case where the Host header contains a bare hostname (no port,
+        // no protocol) — the RFC 7230 compliant form. parse_url cannot resolve such
+        // strings to a host on its own, so hostName() must normalise first.
+        Director::config()->set('alternate_base_url', null);
+
+        $request = new HTTPRequest('GET', '/');
+        $request->addHeader('Host', 'www.mysite.com');
+
+        $this->assertEquals('www.mysite.com', Director::host($request));
+        $this->assertEquals('www.mysite.com', Director::hostName($request));
+        $this->assertNull(Director::port($request));
+    }
+
     public function testIsRelativeUrl()
     {
         $this->assertFalse(Director::is_relative_url('http://test.com'));


### PR DESCRIPTION
## Description

`Director::hostName()` returns `null` when the resolved host is a bare hostname (no port, no protocol) — for example, the RFC 7230-compliant `Host` header value `example.com`. PHP's `parse_url()` interprets such a string as a path and returns `null` for `PHP_URL_HOST`, so the wrapping `?: null` propagates that null upwards and consumers receive `null` instead of the expected hostname.

The fix delegates to `protocolAndHost()` so `parse_url()` always receives a scheme-prefixed URL, which it can parse reliably regardless of whether the host carries a port or not.

The bug was reported (#11081) and reproduces verbatim against the current `6.2` branch.

## Manual testing steps

1. Configure a Silverstripe project so that `Director::host()` resolves via `$_SERVER['HTTP_HOST']` (i.e. unset `alternate_base_url` / no trusted-proxy override).
2. Send a request where the `Host` header is a bare hostname without a port, e.g. `Host: example.com`.
3. Before this PR: `Director::hostName()` returns `null`. After this PR: it returns `"example.com"`.

The included unit test (`DirectorTest::testHostNameWithoutPort`) reproduces this without needing a live server.

## Issues

- #11081

## Pull request checklist

- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR
- [x] The commit messages follow our commit message guidelines
- [x] The PR follows our contribution guidelines
- [x] Code changes follow our coding conventions
- [x] This change is covered with tests
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green