### PR TITLE
Security: add allowed_classes to Form::getSessionValidationResult() unserialize()

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -502,7 +502,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
     {
         $resultData = $this->getSession()->get("FormInfo.{$this->FormName()}.result");
         if (isset($resultData)) {
-            return unserialize($resultData ?? '');
+            return unserialize($resultData ?? '', ['allowed_classes' => [ValidationResult::class]]);
         }
         return null;
     }


### PR DESCRIPTION
## Summary

Add explicit `allowed_classes` restriction to the `unserialize()` call in `Form::getSessionValidationResult()`.

## Vulnerability

`Form::getSessionValidationResult()` (Form.php line 505) deserializes a `ValidationResult` from session storage without an `allowed_classes` restriction:

```php
return unserialize($resultData ?? '');
```

The session data is user-controlled (read from `FormInfo.{FormName}.result` in the user's session). An attacker who can control session contents — via session fixation, a storage backend compromise, or a chained injection bug — can supply a crafted serialized payload that instantiates arbitrary PHP classes, exploiting gadget chains present in the application's dependencies.

## Fix

Restrict deserialization to only the expected class:

```php
return unserialize($resultData ?? '', ['allowed_classes' => [ValidationResult::class]]);
```

The deserialized value is **always** expected to be a `ValidationResult`. The `setSessionValidationResult()` method on the same class only ever stores a `ValidationResult` object, confirming the allowlist is complete.

## References

- PHP unserialize `allowed_classes`: https://www.php.net/manual/en/function.unserialize.php
- OWASP PHP Object Injection: https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection
