### PR TITLE
ENH Increase performance of enum obsolete values for large tables

### DIFF
--- a/src/Dev/Command/DbBuild.php
+++ b/src/Dev/Command/DbBuild.php
@@ -220,40 +220,42 @@ class DbBuild extends DevCommand implements PermissionProvider
     protected function updateLegacyClassNameField(string $dataClass, string $fieldName, array $mapping): void
     {
         $schema = DataObject::getSchema();
-        // Check first to ensure that the class has the specified field to update
-        if (!$schema->databaseField($dataClass, $fieldName, false)) {
+
+        if (!$schema->databaseField($dataClass, $fieldName, false) || empty($mapping)) {
             return;
         }
 
-        // Load a list of any records that have obsolete class names
-        $table = $schema->tableName($dataClass);
-        $currentClassNameList = DB::query("SELECT DISTINCT(\"{$fieldName}\") FROM \"{$table}\"")->column();
-
-        // Get all invalid classes for this field
-        $invalidClasses = array_intersect($currentClassNameList ?? [], array_keys($mapping ?? []));
-        if (!$invalidClasses) {
-            return;
-        }
-
-        $numberClasses = count($invalidClasses ?? []);
-        DB::alteration_message(
-            "Correcting obsolete {$fieldName} values for {$numberClasses} outdated types",
-            'obsolete'
-        );
-
-        // Build case assignment based on all intersected legacy classnames
         $cases = [];
         $params = [];
-        foreach ($invalidClasses as $invalidClass) {
+        $wherePlaceholders = [];
+        $whereParams = [];
+
+        foreach ($mapping as $oldClass => $newClass) {
             $cases[] = "WHEN \"{$fieldName}\" = ? THEN ?";
-            $params[] = $invalidClass;
-            $params[] = $mapping[$invalidClass];
+            $params[] = $oldClass;
+            $params[] = $newClass;
+
+            $wherePlaceholders[] = '?';
+            $whereParams[] = $oldClass;
         }
 
+        $casesSQL = implode(' ', $cases);
+        $wherePlaceholders = implode(',', $wherePlaceholders);
+        $params = array_merge($params, $whereParams);
+
         foreach ($this->getClassTables($dataClass) as $table) {
-            $casesSQL = implode(' ', $cases);
-            $sql = "UPDATE \"{$table}\" SET \"{$fieldName}\" = CASE {$casesSQL} ELSE \"{$fieldName}\" END";
+            $sql = "UPDATE \"{$table}\"
+                    SET \"{$fieldName}\" = CASE {$casesSQL} ELSE \"{$fieldName}\" END
+                    WHERE \"{$fieldName}\" IN ({$wherePlaceholders})";
+
             DB::prepared_query($sql, $params);
+
+            if (DB::get_conn()->affectedRows() > 0) {
+                DB::alteration_message(
+                    "Corrected obsolete {$fieldName} values in {$table}",
+                    'obsolete'
+                );
+            }
         }
     }
 

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -213,9 +213,42 @@ class DBEnum extends DBString implements Resettable
 
         // Get all enum values
         $enumValues = $this->getEnum();
-        if (DB::get_schema()->hasField($table, $name)) {
-            $existing = DB::query("SELECT DISTINCT \"{$name}\" FROM \"{$table}\"")->column();
-            $enumValues = array_unique(array_merge($enumValues, $existing));
+
+        if (!DB::get_schema()->hasField($table, $name)) {
+            DBEnum::$enum_cache[$table][$name] = $enumValues;
+            return $enumValues;
+        }
+
+        $currentConstraintValues = DB::get_schema()->enumValuesForField($table, $name);
+        $removedValues = array_diff($currentConstraintValues, $enumValues);
+
+        if (empty($removedValues)) {
+            DBEnum::$enum_cache[$table][$name] = $enumValues;
+            return $enumValues;
+        }
+
+        $obsoleteValues = [];
+        foreach ($removedValues as $value) {
+            $exists = DB::prepared_query(
+                "SELECT EXISTS(
+                    SELECT 1 FROM \"{$table}\"
+                    WHERE \"{$name}\" = ?
+                    LIMIT 1
+                ) as \"_exists\"",
+                [$value]
+            )->value();
+
+            if ($exists) {
+                $obsoleteValues[] = $value;
+            }
+        }
+
+        if (!empty($obsoleteValues)) {
+            DB::alteration_message(
+                "Found obsolete {$name} values in {$table}: " . implode(', ', $obsoleteValues),
+                'notice'
+            );
+            $enumValues = array_merge($enumValues, $obsoleteValues);
         }
 
         // Cache and return


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
I have a database with relative large tables. When I run db:build its hangs multiple minutes for checking if the database still contains old enum values.

I found the origin and patched it for me in the past. As we use postgres I think it be a niche issue.

I am not completly sure why, but for large tables this can be realy slow:

```
QUERY PLAN
Unique  (cost=1000.46..588711.55 rows=1 width=10) (actual time=2764.849..2786.626 rows=1 loops=1)
  ->  Gather Merge  (cost=1000.46..588711.55 rows=2 width=10) (actual time=2764.848..2786.615 rows=3 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Unique  (cost=0.44..587711.29 rows=1 width=10) (actual time=0.062..1831.997 rows=1 loops=3)
"              ->  Parallel Index Only Scan using ix_e3dc4f5497f7676548ca90e713c5e001 on ""Container_Versions""  (cost=0.44..559543.66 rows=11267055 width=10) (actual time=0.060..1187.245 rows=9052704 loops=3)"
                    Heap Fetches: 6232848
Planning Time: 0.160 ms
JIT:
  Functions: 4
"  Options: Inlining true, Optimization true, Expressions true, Deforming true"
"  Timing: Generation 0.591 ms, Inlining 150.968 ms, Optimization 23.279 ms, Emission 23.194 ms, Total 198.031 ms"
Execution Time: 2786.999 ms
```

A group by does't help either.

My solution:

I fetch the current schema of the enum column, compare it to the new schema.

Than I check for the obsolete classes if any of them exists in the table. I don't know why but a EXISTS-Query is fast 🤷 

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11986

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
