### PR TITLE
ENH Add support for paratest

### DIFF
--- a/src/Core/TempFolder.php
+++ b/src/Core/TempFolder.php
@@ -23,6 +23,11 @@ class TempFolder
         // Append php version to username folder to avoid issues when upgrading php
         $folderName .= '-' . preg_replace('/[^\w\-\.+]+/', '-', PHP_VERSION);
 
+        // Append paratest token to the folder name
+        if (($token = getenv('TEST_TOKEN')) !== false) {
+            $folderName .= '-' . $token;
+        }
+
         // The actual temp folder is a subfolder of getTempParentFolder()
         $subfolder = Path::join($parent, $folderName);
 

--- a/src/ORM/Connect/TempDatabase.php
+++ b/src/ORM/Connect/TempDatabase.php
@@ -56,11 +56,13 @@ class TempDatabase
      */
     protected function isDBTemp($name)
     {
-        $prefix = Environment::getEnv('SS_DATABASE_PREFIX') ?: 'ss_';
+        $prefix = preg_quote(Environment::getEnv('SS_DATABASE_PREFIX') ?: 'ss_', '/') . '([0-9]+_)?';
+
         $result = preg_match(
-            sprintf('/^%stmpdb_[0-9]+_[0-9]+$/i', preg_quote($prefix ?? '', '/')),
+            sprintf('/^%stmpdb_[0-9]+_[0-9]+$/i', $prefix),
             $name ?? ''
         );
+
         return $result === 1;
     }
 
@@ -198,6 +200,11 @@ class TempDatabase
         // Create a temporary database, and force the connection to use UTC for time
         $dbConn = $this->getConn();
         $prefix = Environment::getEnv('SS_DATABASE_PREFIX') ?: 'ss_';
+
+        if (($token = getenv('TEST_TOKEN')) !== false) {
+            $prefix .= $token . '_';
+        }
+
         do {
             $dbname = strtolower(sprintf('%stmpdb_%s_%s', $prefix, time(), rand(1000000, 9999999)));
         } while ($dbConn->databaseExists($dbname));


### PR DESCRIPTION
## Description
The [paratest](https://github.com/paratestphp/paratest) library allows it to run multiple tests in parallel. To ensure that the tests don't inference with each other, a TEST_TOKEN is provided which must be added to the database-name and temp folder.

## Issues
- #11148

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
