### PR TITLE
FIX Correct hex escape pattern in i18nTextCollector

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -938,7 +938,7 @@ class i18nTextCollector
             );
         } elseif (preg_match('/^\"(?<text>.*)\"$/s', $text ?? '', $matches)) {
             $text = preg_replace_callback(
-                '/\\\\([nrtvf\\\\$"]|[0-7]{1,3}|\x[0-9A-Fa-f]{1,2})/s', // rich replacement
+                '/\\\\([nrtvf\\\\$"]|[0-7]{1,3}|x[0-9A-Fa-f]{1,2})/s', // rich replacement
                 function ($input) {
                     return stripcslashes($input[0] ?? '');
                 },


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11990

A regex typo (\x instead of x) meant to match \xNN hex escapes in _t() strings actually told PCRE to parse a hex code, which newer PCRE2 (10.43+) rejects as a hard compile error -- crashing text collection. Dropping the backslash matches a plain literal x, which  is valid in every PCRE version, so it's fully backwards-compatible.