### PR TITLE
FIX Prevent RCE via translation default strings

### DIFF
--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -335,12 +335,32 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function Translate_Default(&$res, $sub)
     {
-        $res['php'] .= ",$sub[text]";
+        $res['php'] .= ',' . $this->getQuotedStringAsPhpLiteral($sub);
     }
 
     function Translate_Context(&$res, $sub)
     {
-        $res['php'] .= ",$sub[text]";
+        $res['php'] .= ',' . $this->getQuotedStringAsPhpLiteral($sub);
+    }
+
+    /**
+     * Convert a matched QuotedString into a safe single-quoted PHP string literal.
+     *
+     * The default and context strings of a <%t %> block are author controlled. Emitting the raw
+     * matched text (which is a double-quoted literal) directly into the compiled template allowed
+     * PHP within the string - e.g. "{${'shell_exec'('id')}}" - to be evaluated when the template
+     * ran, resulting in remote code execution. Decoding the template level backslash escapes and
+     * re-emitting as a single-quoted literal ensures the string is treated as inert text.
+     */
+    private function getQuotedStringAsPhpLiteral($sub)
+    {
+        // The inner string (without the surrounding quotes), with template level escape sequences intact.
+        $string = $sub['String']['text'] ?? '';
+        // Decode the backslash escapes permitted by the QuotedString grammar (\\ and \<char>) so that
+        // the resulting value matches what the previous double-quoted handling produced for common cases.
+        $string = preg_replace('/\\\\(.)/', '$1', $string ?? '');
+        // Emit as a single-quoted PHP literal, which does not interpolate variables or expressions.
+        return "'" . str_replace(['\\', "'"], ['\\\\', "\\'"], $string) . "'";
     }
 
     function Translate_InjectionVariables(&$res, $sub)

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -987,12 +987,32 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function Translate_Default(&$res, $sub)
     {
-        $res['php'] .= ",$sub[text]";
+        $res['php'] .= ',' . $this->getQuotedStringAsPhpLiteral($sub);
     }
 
     function Translate_Context(&$res, $sub)
     {
-        $res['php'] .= ",$sub[text]";
+        $res['php'] .= ',' . $this->getQuotedStringAsPhpLiteral($sub);
+    }
+
+    /**
+     * Convert a matched QuotedString into a safe single-quoted PHP string literal.
+     *
+     * The default and context strings of a <%t %> block are author controlled. Emitting the raw
+     * matched text (which is a double-quoted literal) directly into the compiled template allowed
+     * PHP within the string - e.g. "{${'shell_exec'('id')}}" - to be evaluated when the template
+     * ran, resulting in remote code execution. Decoding the template level backslash escapes and
+     * re-emitting as a single-quoted literal ensures the string is treated as inert text.
+     */
+    private function getQuotedStringAsPhpLiteral($sub)
+    {
+        // The inner string (without the surrounding quotes), with template level escape sequences intact.
+        $string = $sub['String']['text'] ?? '';
+        // Decode the backslash escapes permitted by the QuotedString grammar (\\ and \<char>) so that
+        // the resulting value matches what the previous double-quoted handling produced for common cases.
+        $string = preg_replace('/\\\\(.)/', '$1', $string ?? '');
+        // Emit as a single-quoted PHP literal, which does not interpolate variables or expressions.
+        return "'" . str_replace(['\\', "'"], ['\\\\', "\\'"], $string) . "'";
     }
 
     function Translate_InjectionVariables(&$res, $sub)

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -103,6 +103,51 @@ class SSViewerTest extends SapphireTest
         $this->assertEquals('Test partial template: phpinfo', trim(preg_replace("/<!--.*-->/U", '', $result ?? '') ?? ''));
     }
 
+    /**
+     * Ensures that the default and context strings of a <%t %> translation block are emitted into the
+     * compiled template as safe single-quoted PHP string literals, rather than being pasted verbatim.
+     * Pasting them verbatim allowed an attacker who controls the default/context string to inject
+     * arbitrary PHP (e.g. via "{${'shell_exec'('id')}}") which would be executed when the compiled
+     * template ran - a remote code execution vulnerability.
+     */
+    public function provideTranslateDefaultDoesNotEvaluatePhp(): array
+    {
+        return [
+            'php-variable-variable-rce' => [
+                'template' => '<%t Foo.Bar "{${\'strrev\'(\'ec3pr\')}}" %>',
+                // The default string should be returned verbatim, with no PHP evaluation.
+                'expected' => '{${\'strrev\'(\'ec3pr\')}}',
+            ],
+            'simple-variable-interpolation' => [
+                'template' => '<%t Foo.Bar "Hello $foo world" %>',
+                'expected' => 'Hello $foo world',
+            ],
+            'escaped-quote' => [
+                'template' => '<%t Foo.Bar "Quote \" here" %>',
+                'expected' => 'Quote " here',
+            ],
+            'context-string-rce' => [
+                'template' => '<%t Foo.Bar "default text" is "{${\'strrev\'(\'ec3pr\')}}" %>',
+                'expected' => 'default text',
+            ],
+            // A trailing backslash must be escaped when emitted as a single-quoted literal, otherwise it
+            // would escape the closing quote and break out of the string.
+            'trailing-backslash' => [
+                'template' => '<%t Foo.Bar "foo\\\\" %>',
+                'expected' => 'foo\\',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTranslateDefaultDoesNotEvaluatePhp
+     */
+    public function testTranslateDefaultDoesNotEvaluatePhp(string $template, string $expected): void
+    {
+        $result = $this->render($template);
+        $this->assertEquals($expected, trim($result ?? ''));
+    }
+
     public function testIncludeScopeInheritance()
     {
         $data = $this->getScopeInheritanceTestData();


### PR DESCRIPTION
framework-core suite failures are existing and were fixed in CMS 6.2 - https://github.com/silverstripe/silverstripe-framework/pull/11991 - but we won't be backporting the fix to CMS 5.4