### PR TITLE
API Allow to filter for classes which are annoted by an attribute

### DIFF
--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -3,16 +3,17 @@
 namespace SilverStripe\Core;
 
 use Exception;
+use Psr\SimpleCache\CacheInterface;
+use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionObject;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
-use SilverStripe\Model\ModelData;
-use Psr\SimpleCache\CacheInterface;
-use SilverStripe\Core\Flushable;
-use SilverStripe\Core\Injector\Injector;
 
 /**
  * Provides introspection information about the class tree.
@@ -205,6 +206,43 @@ class ClassInfo implements Flushable
     }
 
     /**
+     * Get the list of classes which are annonated by a given attribute
+     *
+     * @param class-string $attribute Name of a attribute class or an interface
+     * @param bool $instanceOf Should subclasses of the Attribute be included?
+     * @param "classes"|"interfaces"|"traits"|"enums" $type Which type of structure should returned, defaults to "classes"
+     * @return array
+     */
+    public static function annotatedBy(string $attribute, bool $instanceOf = true, string $type = 'classes'): array
+    {
+        return ClassLoader::inst()->getManifest()->getAnnotatedBy($attribute, $instanceOf, $type);
+    }
+
+    /**
+     * @param string $className
+     * @param string $attributeName
+     * @param bool $instanceOf
+     * @return array
+     */
+    public static function getAttributes(string|object $className, string $attributeName, bool $instanceOf = true): array
+    {
+        if (is_object($className)) {
+            $reflection = new ReflectionObject($className);
+        } else {
+            $reflection = new ReflectionClass($className);
+        }
+
+        $filter = $instanceOf ? ReflectionAttribute::IS_INSTANCEOF : 0;
+        $attributes = [];
+
+        foreach ($reflection->getAttributes($attributeName, $filter) as $attribute) {
+            $attributes[] = $attribute->newInstance();
+        }
+
+        return $attributes;
+    }
+
+    /**
      * Convert a class name in any case and return it as it was defined in PHP
      *
      * eg: ClassInfo::class_name('dataobJEct'); //returns 'DataObject'
@@ -279,6 +317,16 @@ class ClassInfo implements Flushable
     }
 
     /**
+     * @param string $interfaceName
+     * @return array A self-keyed array of class names with lowercase keys and correct-case values.
+     * Note that this is only available with Silverstripe classes and not built-in PHP classes.
+     */
+    public static function implementorsOfIncludingChildren(string $interfaceName): array
+    {
+        return ClassLoader::inst()->getManifest()->getImplementorsOfIncludingChildren($interfaceName);
+    }
+
+    /**
      * Returns true if the given class implements the given interface
      *
      * @param string $className
@@ -289,6 +337,20 @@ class ClassInfo implements Flushable
     {
         $lowerClassName = strtolower($className ?? '');
         $implementors = ClassInfo::implementorsOf($interfaceName);
+        return isset($implementors[$lowerClassName]);
+    }
+
+    /**
+     * Returns true if the given class implements the given interface
+     *
+     * @param string $className
+     * @param string $interfaceName
+     * @return bool
+     */
+    public static function classImplementsIncludingChildren($className, $interfaceName)
+    {
+        $lowerClassName = strtolower($className ?? '');
+        $implementors = ClassInfo::implementorsOfIncludingChildren($interfaceName);
         return isset($implementors[$lowerClassName]);
     }
 

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -11,6 +11,7 @@ use PhpParser\ParserFactory;
 use PhpParser\ErrorHandler\ErrorHandler;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Dev\TestOnly;
 
 /**
@@ -75,10 +76,13 @@ class ClassManifest
         'interfaces',
         'interfaceNames',
         'implementors',
+        'annotated',
         'traits',
         'traitNames',
         'enums',
         'enumNames',
+        'attributes',
+        'attributeNames',
     ];
 
     /**
@@ -126,6 +130,36 @@ class ClassManifest
     protected $descendants = [];
 
     /**
+     * List of root interface with no parent interface
+     * Keys are lowercase, values are correct case.
+     *
+     * Note: Only used while regenerating cache
+     *
+     * @var array
+     */
+    protected array $interfaceRoots = [];
+
+    /**
+     * List of direct children for any interface.
+     * Keys are lowercase, values are arrays.
+     * Each item-value array has lowercase keys and correct case for values.
+     *
+     * Note: Only used while regenerating cache
+     *
+     * @var array
+     */
+    protected array $interfaceChildren = [];
+
+    /**
+     * List of descendents for any interface (direct + indirect children)
+     * Keys are lowercase, values are arrays.
+     * Each item-value array has lowercase keys and correct case for values.
+     *
+     * @var array
+     */
+    protected $interfaceDescendants = [];
+
+    /**
      * Map of lowercase interface name to path those files
      *
      * @var array
@@ -147,6 +181,15 @@ class ClassManifest
      * @var array
      */
     protected $implementors = [];
+
+    /**
+     * List of classes which are annoated by an attribute
+     * Keys are lowercase, values are arrays.
+     * Each item-value array has lowercase keys and correct case for values.
+     *
+     * @var array
+     */
+    protected array $annotated = [];
 
     /**
      * Map of lowercase trait names to paths
@@ -175,6 +218,20 @@ class ClassManifest
      * @var array
      */
     protected $enumNames = [];
+
+    /**
+     * Map of lowercase attribute names to paths
+     *
+     * @var array
+     */
+    protected array $attributes = [];
+
+    /**
+     * Map of lowercase attribute names to proper case
+     *
+     * @var array
+     */
+    protected array $attributeNames = [];
 
     /**
      * PHP Parser for parsing found files
@@ -360,11 +417,12 @@ class ClassManifest
     {
         $lowerName = strtolower($name ?? '');
         foreach ([
-                     $this->classes,
-                     $this->interfaces,
-                     $this->traits,
-                     $this->enums,
-                 ] as $source) {
+            $this->classes,
+            $this->interfaces,
+            $this->traits,
+            $this->enums,
+            $this->attributes,
+        ] as $source) {
             if (isset($source[$lowerName]) && file_exists($source[$lowerName] ?? '')) {
                 return $source[$lowerName];
             }
@@ -382,11 +440,12 @@ class ClassManifest
     {
         $lowerName = strtolower($name ?? '');
         foreach ([
-                     $this->classNames,
-                     $this->interfaceNames,
-                     $this->traitNames,
-                     $this->enumNames,
-                 ] as $source) {
+            $this->classNames,
+            $this->interfaceNames,
+            $this->traitNames,
+            $this->enumNames,
+            $this->attributeNames,
+        ] as $source) {
             if (isset($source[$lowerName])) {
                 return $source[$lowerName];
             }
@@ -455,6 +514,26 @@ class ClassManifest
     }
 
     /**
+     * Returns a map of lowercased attribute names to file paths.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Returns a map of lowercase attribute names to proper attribute names in the manifest
+     *
+     * @return array
+     */
+    public function getAttributeNames()
+    {
+        return $this->attributeNames;
+    }
+
+    /**
      * Returns an array of all the descendant data.
      *
      * @return array
@@ -462,6 +541,16 @@ class ClassManifest
     public function getDescendants()
     {
         return $this->descendants;
+    }
+
+    /**
+     * Returns an array of all the descendant data.
+     *
+     * @return array
+     */
+    public function getInterfaceDescendants(): array
+    {
+        return $this->interfaceDescendants;
     }
 
     /**
@@ -480,6 +569,24 @@ class ClassManifest
         $lClass = strtolower($class ?? '');
         if (array_key_exists($lClass, $this->descendants ?? [])) {
             return $this->descendants[$lClass];
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns an array containing all the descendants (direct and indirect)
+     * of a class.
+     *
+     * @param  string $interface
+     * @return array
+     */
+    public function getDescendantsOfInterface(string $interface): array
+    {
+        $lowerInterface = strtolower($interface);
+
+        if (array_key_exists($lowerInterface, $this->interfaceDescendants)) {
+            return $this->interfaceDescendants[$lowerInterface];
         }
 
         return [];
@@ -534,6 +641,74 @@ class ClassManifest
     }
 
     /**
+     * @param string $interface
+     * @return void
+     */
+    public function getImplementorsOfIncludingChildren(string $interface): array
+    {
+        $results = $this->getImplementorsOf($interface);
+
+        foreach ($this->getDescendantsOfInterface($interface) as $subInterface) {
+            $results = array_merge($results, $this->getImplementorsOf($subInterface));
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get an array containing a list of attributes and classes which are annotated by them
+     *
+     * @return array
+     */
+    public function getAnnotated(): array
+    {
+        return $this->annotated;
+    }
+
+    /**
+     * Get the list of classes which are annonated by a given attribute
+     *
+     * @param class-string $attribute
+     * @param bool $instanceOf
+     * @param 'classes'|'traits'|'interfaces'|'enums' $type
+     * @return array
+     */
+    public function getAnnotatedBy(string $attribute, bool $instanceOf = true, string $type = 'classes'): array
+    {
+        if (!in_array($type, ['classes', 'interfaces', 'traits', 'enums'], true)) {
+            throw new \InvalidArgumentException('$type must be one of classes, interfaces, traits, or enums');
+        }
+
+        $isInterface = (
+            interface_exists($attribute)
+            || isset($this->interfaces[strtolower($attribute)]) // Extra check to support internal lower case class-names
+        );
+
+        if ($instanceOf || $isInterface) {
+            if ($isInterface) {
+                $attributeClasses = $this->getImplementorsOfIncludingChildren($attribute);
+            } else {
+                $attributeClasses = $this->getDescendantsOf($attribute);
+                array_unshift($attributeClasses, $attribute);
+            }
+        } else {
+            $attributeClasses = [$attribute];
+        }
+
+        $classes = [];
+
+        foreach ($attributeClasses as $attributeClass) {
+            $lowerAttributeClass = strtolower($attributeClass);
+
+            if (array_key_exists($lowerAttributeClass, $this->annotated)) {
+                $classes = array_merge($classes, $this->annotated[$lowerAttributeClass][$type] ?? []);
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
      * Get module that owns this class
      *
      * @param string $class Class name
@@ -570,6 +745,10 @@ class ClassManifest
 
         foreach ($this->roots as $root) {
             $this->coalesceDescendants($root);
+        }
+
+        foreach ($this->interfaceRoots as $root) {
+            $this->coalesceInterfaceDescendants($root);
         }
 
         if ($this->cache) {
@@ -657,24 +836,6 @@ class ClassManifest
             $this->classes[$lowerClassName] = $pathname;
             $this->classNames[$lowerClassName] = $className;
 
-            // Add to children
-            if ($classInfo['extends']) {
-                foreach ($classInfo['extends'] as $ancestor) {
-                    $lowerAncestor = strtolower($ancestor ?? '');
-                    if (!isset($this->children[$lowerAncestor])) {
-                        $this->children[$lowerAncestor] = [];
-                    }
-                    $this->children[$lowerAncestor][$lowerClassName] = $className;
-                }
-
-                // If the class extends a core class, add class to roots
-                if (strpos($ancestor, 'SilverStripe\\Control') === 0) {
-                    $this->roots[$lowerAncestor] = $ancestor;
-                }
-            } else {
-                $this->roots[$lowerClassName] = $className;
-            }
-
             // Load interfaces
             foreach ($classInfo['interfaces'] as $interface) {
                 $lowerInterface = strtolower($interface ?? '');
@@ -683,6 +844,22 @@ class ClassManifest
                 }
                 $this->implementors[$lowerInterface][$lowerClassName] = $className;
             }
+
+            $this->handleChildren(
+                $this->roots,
+                $this->children,
+                $className,
+                $lowerClassName,
+                $classInfo
+            );
+
+            $this->handleAttributes(
+                'classes',
+                $pathname,
+                $className,
+                $lowerClassName,
+                $classInfo
+            );
         }
 
         // Merge all found interfaces into list
@@ -690,6 +867,22 @@ class ClassManifest
             $lowerInterface = strtolower($interfaceName ?? '');
             $this->interfaces[$lowerInterface] = $pathname;
             $this->interfaceNames[$lowerInterface] = $interfaceName;
+
+            $this->handleChildren(
+                $this->interfaceRoots,
+                $this->interfaceChildren,
+                $interfaceName,
+                $lowerInterface,
+                $interfaceInfo
+            );
+
+            $this->handleAttributes(
+                'interfaces',
+                $pathname,
+                $interfaceName,
+                $lowerInterface,
+                $interfaceInfo,
+            );
         }
 
         // Merge all traits
@@ -697,6 +890,14 @@ class ClassManifest
             $lowerTrait = strtolower($traitName ?? '');
             $this->traits[$lowerTrait] = $pathname;
             $this->traitNames[$lowerTrait] = $traitName;
+
+            $this->handleAttributes(
+                'traits',
+                $pathname,
+                $traitName,
+                $lowerTrait,
+                $traitInfo,
+            );
         }
 
         // Merge all enums
@@ -704,6 +905,14 @@ class ClassManifest
             $lowerEnum = strtolower($enumName ?? '');
             $this->enums[$lowerEnum] = $pathname;
             $this->enumNames[$lowerEnum] = $enumName;
+
+            $this->handleAttributes(
+                'enums',
+                $pathname,
+                $enumName,
+                $lowerEnum,
+                $enumInfo,
+            );
         }
 
         // Save back to cache if configured
@@ -716,6 +925,66 @@ class ClassManifest
             ];
 
             $this->filesCache[$key] = $cache;
+        }
+    }
+
+    protected function handleChildren(
+        array &$roots,
+        array &$children,
+        string $className,
+        string $lowerClassName,
+        array $classInfo
+    ): void {
+        // Add to children
+        if ($classInfo['extends']) {
+            $ancestor = '';
+            $lowerAncestor = '';
+
+            foreach ($classInfo['extends'] as $ancestor) {
+                $lowerAncestor = strtolower($ancestor ?? '');
+                if (!isset($children[$lowerAncestor])) {
+                    $children[$lowerAncestor] = [];
+                }
+                $children[$lowerAncestor][$lowerClassName] = $className;
+            }
+
+            // If the class extends a core class, add class to roots
+            if (str_starts_with($ancestor, 'SilverStripe\\Control')) {
+                $roots[$lowerAncestor] = $ancestor;
+            }
+        } else {
+            $roots[$lowerClassName] = $className;
+        }
+    }
+
+    protected function handleAttributes(
+        string $type,
+        string $pathname,
+        string $className,
+        string $lowerClassName,
+        array $classInfo
+    ): void {
+        if (isset($classInfo['attributes'])) {
+            foreach ($classInfo['attributes'] as $attributeName) {
+                $lowerAttributeName = strtolower($attributeName);
+
+                if (!isset($this->annotated[$lowerAttributeName])) {
+                    $this->annotated[$lowerAttributeName] = [
+                        'classes' => [],
+                        'interfaces' => [],
+                        'traits' => [],
+                        'enums' => [],
+                    ];
+                }
+
+                $this->annotated[$lowerAttributeName][$type][$lowerClassName] = $className;
+
+                // Class is a attribute append it to the list of attribute classes
+                if ($type === 'classes' && $lowerAttributeName == 'attribute') {
+                    $this->attributes[$lowerClassName] = $pathname;
+                    $this->attributeNames[$lowerClassName] = $className;
+                }
+            }
         }
     }
 
@@ -744,6 +1013,33 @@ class ClassManifest
             );
         }
         return $this->descendants[$lowerClass];
+    }
+
+    /**
+     * Recursively coalesces direct child information into full descendant
+     * information.
+     *
+     * @param string $interface
+     * @return array
+     */
+    protected function coalesceInterfaceDescendants(string $interface): array
+    {
+        // Reset descendents to immediate children initially
+        $lowerInterface = strtolower($interface);
+        if (empty($this->interfaceChildren[$lowerInterface])) {
+            return [];
+        }
+
+        // Coalesce children into descendent list
+        $this->interfaceDescendants[$lowerInterface] = $this->interfaceChildren[$lowerInterface];
+        foreach ($this->interfaceChildren[$lowerInterface] as $childInterface) {
+            // Merge all nested descendants
+            $this->interfaceDescendants[$lowerInterface] = array_merge(
+                $this->interfaceDescendants[$lowerInterface],
+                $this->coalesceInterfaceDescendants($childInterface)
+            );
+        }
+        return $this->interfaceDescendants[$lowerInterface];
     }
 
     /**
@@ -801,10 +1097,17 @@ class ClassManifest
             if (!is_array($data[$key])) {
                 return false;
             }
-            // Detect legacy cache keys (non-associative)
             $array = $data[$key];
-            if (!empty($array) && is_numeric(key($array ?? []))) {
-                return false;
+            if (!empty($array)) {
+                $key = key($array ?? []);
+                // Detect legacy cache keys (non-associative)
+                if (is_numeric($key)) {
+                    return false;
+                }
+                // Detect missing attributes
+                if (!isset($array[$key]['attributes'])) {
+                    return false;
+                }
             }
         }
         return true;

--- a/src/Core/Manifest/ClassManifestVisitor.php
+++ b/src/Core/Manifest/ClassManifestVisitor.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Core\Manifest;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
@@ -47,33 +48,52 @@ class ClassManifestVisitor extends NodeVisitorAbstract
                 $extends = [(string)$node->extends];
             }
 
-            if ($node->implements) {
-                foreach ($node->implements as $interface) {
-                    $interfaces[] = (string)$interface;
-                }
-            }
-
             $this->classes[(string)$node->namespacedName] = [
                 'extends' => $extends,
-                'interfaces' => $interfaces,
+                'interfaces' => $this->getClassNames($node->implements),
+                'attributes' => $this->getAttributes($node),
             ];
         } elseif ($node instanceof Node\Stmt\Trait_) {
-            $this->traits[(string)$node->namespacedName] = [];
+            $this->traits[(string)$node->namespacedName] = [
+                'attributes' => $this->getAttributes($node),
+            ];
         } elseif ($this->includeEnums && $node instanceof Node\Stmt\Enum_) {
-            $this->enums[(string)$node->namespacedName] = [];
+            $this->enums[(string)$node->namespacedName] = [
+                'attributes' => $this->getAttributes($node),
+            ];
         } elseif ($node instanceof Node\Stmt\Interface_) {
-            $extends = [];
-            foreach ($node->extends as $ancestor) {
-                $extends[] = (string)$ancestor;
-            }
             $this->interfaces[(string)$node->namespacedName] = [
-                'extends' => $extends,
+                'extends' => $this->getClassNames($node->extends),
+                'attributes' => $this->getAttributes($node),
             ];
         }
         if (!$node instanceof Node\Stmt\Namespace_) {
             //break out of traversal as we only need highlevel information here!
             return NodeTraverser::DONT_TRAVERSE_CHILDREN;
         }
+    }
+
+    private function getClassNames(array $list): array
+    {
+        return array_map(
+            static fn ($classLike) => (string)$classLike,
+            $list
+        );
+    }
+
+    private function getAttributes(ClassLike $classLike): array
+    {
+        $attributes = [];
+
+        if ($classLike->attrGroups) {
+            foreach ($classLike->attrGroups as $group) {
+                foreach ($group->attrs as $attr) {
+                    $attributes[] = (string)$attr->name;
+                }
+            }
+        }
+
+        return $attributes;
     }
 
     public function getClasses()

--- a/tests/php/Core/Manifest/ClassManifestTest.php
+++ b/tests/php/Core/Manifest/ClassManifestTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Core\Tests\Manifest;
 
+use ClassF;
 use Exception;
 use SilverStripe\Core\Manifest\ClassManifest;
 use SilverStripe\Dev\SapphireTest;
@@ -84,6 +85,13 @@ class ClassManifestTest extends SapphireTest
             'classc' => "{$this->base}/module/classes/ClassC.php",
             'classd' => "{$this->base}/module/classes/ClassD.php",
             'classe' => "{$this->base}/module/classes/ClassE.php",
+            'classf' => "{$this->base}/module/classes/ClassF.php",
+            'classg' => "{$this->base}/module/classes/ClassG.php",
+            'classh' => "{$this->base}/module/classes/ClassH.php",
+            'classi' => "{$this->base}/module/classes/ClassI.php",
+            'customattributea' => "{$this->base}/module/classes/CustomAttributeA.php",
+            'customattributeb' => "{$this->base}/module/classes/CustomAttributeB.php",
+            'customattributec' => "{$this->base}/module/classes/CustomAttributeC.php",
             'vendorclassa' => "{$this->base}/vendor/silverstripe/modulec/code/VendorClassA.php",
             'vendorclassx' => "{$this->base}/vendor/silverstripe/modulecbetter/code/VendorClassX.php",
         ];
@@ -99,6 +107,13 @@ class ClassManifestTest extends SapphireTest
                 'classc' => 'ClassC',
                 'classd' => 'ClassD',
                 'classe' => 'ClassE',
+                'classf' => 'ClassF',
+                'classg' => 'ClassG',
+                'classh' => 'ClassH',
+                'classi' => 'ClassI',
+                'customattributea' => 'CustomAttributeA',
+                'customattributeb' => 'CustomAttributeB',
+                'customattributec' => 'CustomAttributeC',
                 'vendorclassa' => 'VendorClassA',
                 'vendorclassx' => 'VendorClassX',
             ],
@@ -128,6 +143,9 @@ class ClassManifestTest extends SapphireTest
             'classc' => [
                 'classd' => 'ClassD',
             ],
+            'customattributeb' => [
+                'customattributec' => 'CustomAttributeC',
+            ]
         ];
         $this->assertEquals($expect, $this->manifest->getDescendants());
     }
@@ -146,11 +164,38 @@ class ClassManifestTest extends SapphireTest
         }
     }
 
+    public function testGetInterfaceDescendants()
+    {
+        $expect = [
+            'interfacec' => [
+                'interfaced' => 'InterfaceD',
+                'interfacee' => 'InterfaceE',
+            ],
+        ];
+        $this->assertEquals($expect, $this->manifest->getInterfaceDescendants());
+    }
+
+    public function testGetDescendantsOfInterface()
+    {
+        $expect = [
+            'interfacec' => ['interfaced' => 'InterfaceD', 'interfacee' => 'InterfaceE'],
+            'INTERFACEC' => ['interfaced' => 'InterfaceD', 'interfacee' => 'InterfaceE'],
+            'InterfaceC' => ['interfaced' => 'InterfaceD', 'interfacee' => 'InterfaceE'],
+        ];
+
+        foreach ($expect as $class => $desc) {
+            $this->assertEquals($desc, $this->manifest->getDescendantsOfInterface($class));
+        }
+    }
+
     public function testGetInterfaces()
     {
         $expect = [
             'interfacea' => "{$this->base}/module/interfaces/InterfaceA.php",
-            'interfaceb' => "{$this->base}/module/interfaces/InterfaceB.php"
+            'interfaceb' => "{$this->base}/module/interfaces/InterfaceB.php",
+            'interfacec' => "{$this->base}/module/interfaces/InterfaceC.php",
+            'interfaced' => "{$this->base}/module/interfaces/InterfaceD.php",
+            'interfacee' => "{$this->base}/module/interfaces/InterfaceE.php",
         ];
         $this->assertEquals($expect, $this->manifest->getInterfaces());
     }
@@ -160,6 +205,8 @@ class ClassManifestTest extends SapphireTest
         $expect = [
             'interfacea' => ['classb' => 'ClassB'],
             'interfaceb' => ['classc' => 'ClassC'],
+            'interfaced' => ['classf' => 'ClassF'],
+            'interfacee' => ['customattributea' => 'CustomAttributeA'],
         ];
         $this->assertEquals($expect, $this->manifest->getImplementors());
     }
@@ -171,10 +218,30 @@ class ClassManifestTest extends SapphireTest
             'interfacea' => ['classb' => 'ClassB'],
             'INTERFACEB' => ['classc' => 'ClassC'],
             'interfaceb' => ['classc' => 'ClassC'],
+            'interfacec' => [], // Must be empty
+            'interfaced' => ['classf' => 'ClassF'],
+            'interfacee' => ['customattributea' => 'CustomAttributeA'],
         ];
 
         foreach ($expect as $interface => $impl) {
             $this->assertEquals($impl, $this->manifest->getImplementorsOf($interface));
+        }
+    }
+
+    public function testGetImplementorsOfIncludingChildren()
+    {
+        $expect = [
+            'INTERFACEA' => ['classb' => 'ClassB'],
+            'interfacea' => ['classb' => 'ClassB'],
+            'INTERFACEB' => ['classc' => 'ClassC'],
+            'interfaceb' => ['classc' => 'ClassC'],
+            'interfacec' => ['classf' => 'ClassF', 'customattributea' => 'CustomAttributeA'],
+            'interfaced' => ['classf' => 'ClassF'],
+            'interfacee' => ['customattributea' => 'CustomAttributeA'],
+        ];
+
+        foreach ($expect as $interface => $impl) {
+            $this->assertEquals($impl, $this->manifest->getImplementorsOfIncludingChildren($interface));
         }
     }
 
@@ -204,6 +271,114 @@ class ClassManifestTest extends SapphireTest
             ],
             $this->manifest->getEnumNames()
         );
+    }
+
+    public function testGetAttributes()
+    {
+        $attributes = [
+            'customattributea' => "{$this->base}/module/classes/CustomAttributeA.php",
+            'customattributeb' => "{$this->base}/module/classes/CustomAttributeB.php",
+            'customattributec' => "{$this->base}/module/classes/CustomAttributeC.php",
+        ];
+
+        $this->assertEquals($attributes, $this->manifest->getAttributes());
+    }
+
+    public function testGetAttributesNames()
+    {
+        $attributes = [
+            'customattributea' => 'CustomAttributeA',
+            'customattributeb' => 'CustomAttributeB',
+            'customattributec' => 'CustomAttributeC',
+        ];
+
+        $this->assertEquals($attributes, $this->manifest->getAttributeNames());
+    }
+
+    public function testGetAnnotated()
+    {
+        $attributes = [
+            'customattributea' => [
+                'classes' => [
+                    'classf' => 'ClassF',
+                    'classg' => 'ClassG',
+                    'classh' => 'ClassH',
+                    'classi' => 'ClassI',
+                ],
+                'interfaces' => [
+                    'interfacec' => 'InterfaceC',
+                ],
+                'traits' => [
+                    'testnamespace\testing\testtraitb' => 'TestNamespace\Testing\TestTraitB',
+                ],
+                'enums' => [
+                    'enumb' => 'EnumB',
+                ],
+            ],
+            'customattributeb' => [
+                'classes' => [
+                    'classg' => 'ClassG',
+                ],
+                'interfaces' => [],
+                'traits' => [],
+                'enums' => [],
+            ],
+            'customattributec' => [
+                'classes' => [
+                    'classi' => 'ClassI',
+                ],
+                'interfaces' => [],
+                'traits' => [],
+                'enums' => [],
+            ],
+            'attribute' => [
+                'classes' => [
+                    'customattributea' => 'CustomAttributeA',
+                    'customattributeb' => 'CustomAttributeB',
+                    'customattributec' => 'CustomAttributeC',
+                ],
+                'interfaces' => [],
+                'traits' => [],
+                'enums' => [],
+            ],
+        ];
+
+        $this->assertEquals($attributes, $this->manifest->getAnnotated());
+    }
+
+    public function testAnnotatedBy()
+    {
+        $expect = [
+            'customattributea' => ['classf' => 'ClassF', 'classg' => 'ClassG', 'classh' => 'ClassH', 'classi' => 'ClassI'],
+            'customattributeb' => ['classg' => 'ClassG', 'classi' => 'ClassI'],
+            'customattributec' => ['classi' => 'ClassI'],
+            'interfacee' => ['classf' => 'ClassF', 'classg' => 'ClassG', 'classh' => 'ClassH', 'classi' => 'ClassI'],
+        ];
+
+        foreach ($expect as $attr => $impl) {
+            $this->assertEquals(
+                $impl,
+                $this->manifest->getAnnotatedBy($attr, true, 'classes'),
+                'Asserting classes annotated by ' . $attr
+            );
+        }
+    }
+
+    public function testAnnotatedByDirect()
+    {
+        $expect = [
+            'customattributea' => ['classf' => 'ClassF', 'classg' => 'ClassG', 'classh' => 'ClassH', 'classi' => 'ClassI'],
+            'customattributeb' => ['classg' => 'ClassG'],
+            'customattributec' => ['classi' => 'ClassI'],
+        ];
+
+        foreach ($expect as $attr => $impl) {
+            $this->assertEquals(
+                $impl,
+                $this->manifest->getAnnotatedBy($attr, false, 'classes'),
+                'Asserting classes annotated directly by ' . $attr
+            );
+        }
     }
 
     public function testTestManifestIncludesTestClasses()

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassF.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassF.php
@@ -3,4 +3,7 @@
  * @ignore
  */
 #[CustomAttributeA]
-enum EnumB {  }
+class ClassF implements InterfaceD
+{
+
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassG.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassG.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @ignore
+ */
+#[CustomAttributeA, CustomAttributeB]
+class ClassG
+{
+
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassH.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassH.php
@@ -3,4 +3,7 @@
  * @ignore
  */
 #[CustomAttributeA]
-enum EnumB {  }
+class ClassH
+{
+
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassI.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/ClassI.php
@@ -3,4 +3,8 @@
  * @ignore
  */
 #[CustomAttributeA]
-enum EnumB {  }
+#[CustomAttributeC]
+class ClassI
+{
+
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/CustomAttributeA.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/CustomAttributeA.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @ignore
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class CustomAttributeA implements InterfaceE
+{
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/CustomAttributeB.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/CustomAttributeB.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @ignore
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class CustomAttributeB
+{
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/CustomAttributeC.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/classes/CustomAttributeC.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @ignore
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class CustomAttributeC extends CustomAttributeB
+{
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/interfaces/InterfaceC.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/interfaces/InterfaceC.php
@@ -3,4 +3,6 @@
  * @ignore
  */
 #[CustomAttributeA]
-enum EnumB {  }
+interface InterfaceC
+{
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/interfaces/InterfaceD.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/interfaces/InterfaceD.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @ignore
+ */
+interface InterfaceD extends InterfaceC
+{
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/interfaces/InterfaceE.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/interfaces/InterfaceE.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @ignore
+ */
+interface InterfaceE extends InterfaceC
+{
+}

--- a/tests/php/Core/Manifest/fixtures/classmanifest/module/traits/TestTraitB.php
+++ b/tests/php/Core/Manifest/fixtures/classmanifest/module/traits/TestTraitB.php
@@ -2,9 +2,12 @@
 
 namespace TestNamespace\Testing;
 
+use CustomAttributeA;
+
 /**
  * @ignore
  */
+#[CustomAttributeA]
 trait TestTraitB {
     //put your code here
 }


### PR DESCRIPTION
Implements #11996

## Description
Add support for attributes to the class manifest. So that you get all classes which are annotated by a given attribute.

I also added something which bothers me for sometime: You currently can't use implementorsOf for interfaces which extends another interface :/. You have to know the child interfaces and call implementsOf manually for all child interfaces ...

## Manual testing steps

```php
#[Attribute(Attribute::TARGET_CLASS)]
class CustomAttribute {}

#[CustomAttribute]
class MyClass {}

var_dump(ClassInfo::annotatedBy(CustomAttribute::class));
```

## Issues
- #11996

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
