### PR TITLE
FIX DataList::columnUnique() deduplicates the requested column

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1797,7 +1797,10 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function columnUnique($colName = "ID")
     {
-        return $this->dataQuery->distinct(true)->column($colName);
+        // Deduplicate in PHP rather than relying on SQL DISTINCT: column() adds the
+        // ORDER BY columns to the SELECT, so a DISTINCT would span multiple columns and
+        // fail to make $colName unique. This matches the other SS_List implementations.
+        return array_unique($this->column($colName));
     }
 
     // Member altering methods

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1800,7 +1800,9 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         // Deduplicate in PHP rather than relying on SQL DISTINCT: column() adds the
         // ORDER BY columns to the SELECT, so a DISTINCT would span multiple columns and
         // fail to make $colName unique. This matches the other SS_List implementations.
-        return array_unique($this->column($colName));
+        // array_unique() preserves keys, so a duplicate that is not last would leave
+        // gaps in the returned list; array_values() re-indexes it.
+        return array_values(array_unique($this->column($colName)));
     }
 
     // Member altering methods

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -2290,6 +2290,21 @@ class DataListTest extends SapphireTest
         $this->assertSame(['Test 1', 'Test 2', 'Test 3'], $list->columnUnique('Title'));
     }
 
+    /**
+     * Regression test for https://github.com/silverstripe/silverstripe-framework/issues/11941
+     * columnUnique() must deduplicate the fetched column even when the list is sorted by a
+     * different column. Relying on SQL DISTINCT fails here because column() adds the ORDER BY
+     * columns to the SELECT, so the DISTINCT spans multiple columns and never makes the
+     * fetched column unique.
+     */
+    public function testColumnUniqueWithDifferentSort()
+    {
+        // 'test3' and 'test3-duplicate' share the Title 'Test 3'; sorting by ID means the
+        // ORDER BY column differs from the fetched Title column.
+        $list = RelationChildSecond::get()->sort('ID');
+        $this->assertSame(['Test 1', 'Test 2', 'Test 3'], $list->columnUnique('Title'));
+    }
+
     public function testColumnFailureInvalidColumn()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Description

`DataList::columnUnique()` relied on SQL `DISTINCT`, but `DataList::column()` adds the `ORDER BY` columns to the `SELECT`. That means the `DISTINCT` spans multiple columns and never makes the requested column unique.

For example, on a list using the default sort:

```php
SiteTree::get()->columnUnique('ParentID'); // returned [0, 0, 0, 0, 0]
```

This deduplicates in PHP with `array_unique($this->column($colName))`, matching the existing `EagerLoadedList` and `UnsavedRelationList` implementations of `columnUnique()`.

## Manual testing steps

```php
// Before: [0, 0, 0, 0, 0]   After: [0]
SiteTree::get()->columnUnique('ParentID');
```

## Issues

- Fixes #11941

## Pull request checklist

- [x] The target branch is correct (lowest supported line the bug applies to; also present on 6)
- [x] All commits are relevant and messages follow the commit message guidelines
- [x] Added unit test (`testColumnUniqueWithDifferentSort`) — it fetches a column while the list is sorted by a *different* column, which the existing test did not cover
- [x] The PR follows the contribution guidelines
