### PR TITLE
FIX i18n text collector regex fails to compile on PCRE2

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -939,7 +939,7 @@ class i18nTextCollector
             );
         } elseif (preg_match('/^\"(?<text>.*)\"$/s', $text ?? '', $matches)) {
             $text = preg_replace_callback(
-                '/\\\\([nrtvf\\\\$"]|[0-7]{1,3}|\x[0-9A-Fa-f]{1,2})/s', // rich replacement
+                '/\\\\([nrtvf\\\\$"]|[0-7]{1,3}|x[0-9A-Fa-f]{1,2})/s', // rich replacement
                 function ($input) {
                     return stripcslashes($input[0] ?? '');
                 },

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -474,6 +474,24 @@ PHP;
         );
     }
 
+    public function testHexEscapesInEntityValues()
+    {
+        $c = i18nTextCollector::create();
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
+
+        // Double-quoted string literals support \xHH hex escapes; \x43 is the letter 'C'.
+        $php = <<<'PHP'
+_t(
+'Test.HEXESCAPE',
+"AB\x43DE"
+);
+PHP;
+        $this->assertEquals(
+            [ 'Test.HEXESCAPE' => 'ABCDE' ],
+            $c->collectFromCode($php, null, $mymodule)
+        );
+    }
+
     /**
      * Test extracting entities from the new _t method signature
      */


### PR DESCRIPTION
## Description

The rich-string replacement regex in `i18nTextCollector::processString()` fails to compile on PCRE2 (PHP 8.x):

```
preg_replace_callback(): Compilation failed: digits missing after \x or in \x{} or \N{U+} at offset 28
```

The offending alternative matched a `\xHH` hex escape with `\x[0-9A-Fa-f]{1,2}`. But the leading backslash of the escape is already consumed by the outer `\\` group, so this alternative should match a **literal `x`** followed by the hex digits. PCRE2 instead reads the stray `\x[` as a malformed hex escape and refuses to compile, which makes `processString()` throw for every double-quoted string literal being collected — this is the cause of the `i18nTextCollectorTest` failures currently showing red across CI.

The fix changes `\x[0-9A-Fa-f]{1,2}` to `x[0-9A-Fa-f]{1,2}`. As a bonus this makes `\xHH` escapes actually decode (previously the alternative never matched a real hex escape).

## Manual testing steps

Collecting a double-quoted entity value containing a hex escape now decodes correctly:

```php
_t('Test.HEXESCAPE', "AB\x43DE"); // collected value: "ABCDE"  (\x43 === 'C')
```

## Issues

- No open issue; surfaced by CI failing on `i18nTextCollectorTest` on newer PHP/PCRE2.

## Pull request checklist

- [x] The target branch is correct (lowest supported line; the same bug is present on `6`)
- [x] All commits are relevant and messages follow the commit message guidelines
- [x] Added a regression test (`testHexEscapesInEntityValues`)
- [x] The PR follows the contribution guidelines
