### PR TITLE
ENH Allow figures/figcaptions to be used in HTMLEditors

### DIFF
--- a/_config/html.yml
+++ b/_config/html.yml
@@ -81,6 +81,20 @@ SilverStripe\Forms\HTMLEditor\HTMLEditorConfig:
       removeIfEmpty: true
       attributes:
         class: true
+    figure:
+      removeIfEmpty: true
+      attributes:
+        id: true
+        class: true
+        style: true
+        dir: true
+    figcaption:
+      removeIfEmpty: true
+      attributes:
+        id: true
+        class: true
+        style: true
+        dir: true
     h1:
       removeIfEmpty: true
       attributes:


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Currently figure/figcaption elements are stripped from HTML fields. Adding this config will allow for more accessible images w/ captions to be generated in content areas

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #12000 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
