### PR TITLE
API Change many_many keys to ForeignKey instead of hardcode it to Int

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3824,8 +3824,8 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
 
                 // Build fields
                 $manymanyFields = [
-                    $parentField => "Int",
-                    $childField => "Int",
+                    $parentField => "ForeignKey",
+                    $childField => "ForeignKey",
                 ];
                 if (isset($extras[$component])) {
                     $manymanyFields = array_merge($manymanyFields, $extras[$component]);

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -38,7 +38,7 @@ class DBForeignKey extends DBInt
 
     private static string $default_search_filter_class = 'ExactMatchFilter';
 
-    public function __construct(?string $name, ?DataObject $object = null)
+    public function __construct(?string $name = null, ?DataObject $object = null)
     {
         $this->object = $object;
         parent::__construct($name);


### PR DESCRIPTION
## Description
Currently the relaiton fields of many_many are hardcoded to Int. I think that should be ForeignKey instead.

(The change to the DBForeignKey that the name defaults to null is needed as it called as a singleton somewhere in the code)

## Issues
- #12002

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
