### PR TITLE
FIX SSViewer::rewriteHashLinks with trailing slash

### DIFF
--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -684,12 +684,6 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
             return $url;
         }
 
-        // Do not modify files
-        $extension = pathinfo(Director::makeRelative($url), PATHINFO_EXTENSION);
-        if ($extension) {
-            return $url;
-        }
-
         $querystring = null;
         $fragmentIdentifier = null;
 
@@ -702,17 +696,23 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
             list($url, $querystring) = explode('?', $url, 2);
         }
 
-        // Normalise trailing slash
-        $shouldHaveTrailingSlash = Controller::config()->uninherited('add_trailing_slash');
-        if ($shouldHaveTrailingSlash && !str_ends_with($url, '/')) {
-            $url .= '/';
-        } elseif (!$shouldHaveTrailingSlash) {
-            $url = rtrim($url, '/');
-        }
+        // Do not modify files
+        // The extension is checked against the path only, as a dot in the querystring or fragment
+        // identifier does not make the URL a file
+        $extension = pathinfo(Director::makeRelative($url), PATHINFO_EXTENSION);
+        if (!$extension) {
+            // Normalise trailing slash
+            $shouldHaveTrailingSlash = Controller::config()->uninherited('add_trailing_slash');
+            if ($shouldHaveTrailingSlash && !str_ends_with($url, '/')) {
+                $url .= '/';
+            } elseif (!$shouldHaveTrailingSlash) {
+                $url = rtrim($url, '/');
+            }
 
-        // Ensure relative root URLs are represented with a slash
-        if ($url === '') {
-            $url = '/';
+            // Ensure relative root URLs are represented with a slash
+            if ($url === '') {
+                $url = '/';
+            }
         }
 
         // Add back fragment identifier and querystrings

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -7,6 +7,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\FieldType\DBField;
@@ -370,14 +371,14 @@ class SSViewer
             $url = '/' . $request->getURL(true);
             if ($rewritePHP) {
                 $thisURLRelativeToBase = <<<PHP
-                <?php echo \\SilverStripe\\Core\\Convert::raw2att(preg_replace(
+                <?php echo \\SilverStripe\\Core\\Convert::raw2att(\\SilverStripe\\Control\\Controller::normaliseTrailingSlash(preg_replace(
                     "/^(\\\\/)+/",
                     "/",
                     \$_SERVER['REQUEST_URI'] ?? SilverStripe\\Control\\Controller::curr()?->getRequest()?->getURL(true) ?? '$url'
-                )); ?>
+                ))); ?>
                 PHP;
             } else {
-                $thisURLRelativeToBase = Convert::raw2att($url);
+                $thisURLRelativeToBase = Convert::raw2att(Controller::normaliseTrailingSlash($url));
             }
 
             $output = preg_replace('/(<a[^>]+href *= *)"#/i', '\\1"' . $thisURLRelativeToBase . '#', $output ?? '');

--- a/tests/php/Control/ControllerTest.php
+++ b/tests/php/Control/ControllerTest.php
@@ -634,6 +634,22 @@ class ControllerTest extends FunctionalTest
                 'withSlash' => 'some/path/?key=value&key2=value2#some-id',
                 'withoutSlash' => 'some/path?key=value&key2=value2#some-id',
             ],
+            // A dot in the query string or fragment identifier doesn't make the URL a file
+            [
+                'path' => 'some/path?key=value.ext',
+                'withSlash' => 'some/path/?key=value.ext',
+                'withoutSlash' => 'some/path?key=value.ext',
+            ],
+            [
+                'path' => 'some/path#some.id',
+                'withSlash' => 'some/path/#some.id',
+                'withoutSlash' => 'some/path#some.id',
+            ],
+            [
+                'path' => 'some/path?key=value.ext#some.id',
+                'withSlash' => 'some/path/?key=value.ext#some.id',
+                'withoutSlash' => 'some/path?key=value.ext#some.id',
+            ],
             // Don't ever add a trailing slash to the end of a URL that looks like a file
             [
                 'path' => 'https://www.example.com/some/file.txt',

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\View\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -239,11 +240,11 @@ class SSViewerTest extends SapphireTest
         }
 
         $code = <<<'EOC'
-        <a class="inserted" href="<?php echo \SilverStripe\Core\Convert::raw2att(preg_replace(
+        <a class="inserted" href="<?php echo \SilverStripe\Core\Convert::raw2att(\SilverStripe\Control\Controller::normaliseTrailingSlash(preg_replace(
             "/^(\/)+/",
             "/",
             $_SERVER['REQUEST_URI'] ?? SilverStripe\Control\Controller::curr()?->getRequest()?->getURL(true) ?? '/about-us'
-        )); ?>#anchor">InsertedLink</a>
+        ))); ?>#anchor">InsertedLink</a>
         EOC;
         $this->assertStringContainsString($code, $result);
         $this->assertStringContainsString(
@@ -251,6 +252,82 @@ class SSViewerTest extends SapphireTest
             $result,
             'SSTemplateParser should only rewrite anchor hrefs'
         );
+    }
+
+    public static function provideRewriteHashlinksTrailingSlash(): array
+    {
+        return [
+            'no trailing slash' => [
+                'addTrailingSlash' => false,
+                'url' => 'about-us',
+                'expected' => '/about-us',
+            ],
+            'trailing slash' => [
+                'addTrailingSlash' => true,
+                'url' => 'about-us',
+                'expected' => '/about-us/',
+            ],
+            'no trailing slash with query string' => [
+                'addTrailingSlash' => false,
+                'url' => 'about-us?foo=bar',
+                'expected' => '/about-us?foo=bar',
+            ],
+            'trailing slash with query string' => [
+                'addTrailingSlash' => true,
+                'url' => 'about-us?foo=bar',
+                'expected' => '/about-us/?foo=bar',
+            ],
+            'no trailing slash with a dot in the query string' => [
+                'addTrailingSlash' => false,
+                'url' => 'about-us?foo=bar.baz',
+                'expected' => '/about-us?foo=bar.baz',
+            ],
+            'trailing slash with a dot in the query string' => [
+                'addTrailingSlash' => true,
+                'url' => 'about-us?foo=bar.baz',
+                'expected' => '/about-us/?foo=bar.baz',
+            ],
+            'no trailing slash on home page' => [
+                'addTrailingSlash' => false,
+                'url' => '',
+                'expected' => '/',
+            ],
+            'trailing slash on home page' => [
+                'addTrailingSlash' => true,
+                'url' => '',
+                'expected' => '/',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideRewriteHashlinksTrailingSlash')]
+    public function testRewriteHashlinksTrailingSlash(bool $addTrailingSlash, string $url, string $expected): void
+    {
+        Controller::config()->set('add_trailing_slash', $addTrailingSlash);
+        SSViewer::setRewriteHashLinksDefault(true);
+
+        $origRequest = Injector::inst()->has(HTTPRequest::class)
+            ? Injector::inst()->get(HTTPRequest::class)
+            : null;
+        Injector::inst()->registerService(new HTTPRequest('GET', $url), HTTPRequest::class);
+
+        try {
+            $engine = new DummyTemplateEngine();
+            $engine->setOutput(
+                '<html><head><base href="http://www.example.com/"></head>'
+                . '<body><a href="#anchor">Link</a></body></html>'
+            );
+            $tmpl = new SSViewer([], $engine);
+            $result = $tmpl->process('pretend this is a model');
+        } finally {
+            if ($origRequest) {
+                Injector::inst()->registerService($origRequest, HTTPRequest::class);
+            } else {
+                Injector::inst()->unregisterNamedObject(HTTPRequest::class);
+            }
+        }
+
+        $this->assertStringContainsString('<a href="' . Convert::raw2att($expected) . '#anchor">Link</a>', $result);
     }
 
     public function testGetBaseTag()


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11955

Testing steps

1. Create `app/_config/trailing-slash.yml` with:

```yml
---
Name: trailingslashtest
---
SilverStripe\Control\Controller:
  add_trailing_slash: true
SilverStripe\Core\Injector\Injector:
  SilverStripe\Control\Middleware\CanonicalURLMiddleware:
    properties:
      enforceTrailingSlashConfig: true
```
 
2. Add the task below, run ?flush=1, then run the task to create the mock page

3. Visit `/mock-hash-link-page/`

4. View the page source: the `Jump` link used to render as `<a href="/mock-hash-link-page#anchor">`, without the configured trailing slash, and clicking it caused a full page load (a redirect to `/mock-hash-link-page/#anchor`) instead of scrolling to the anchor; it should now render as `<a href="/mock-hash-link-page/#anchor">`

**app/src/MockHashLinkPageTask.php**

```php
<?php

use SilverStripe\CMS\Model\SiteTree;
use SilverStripe\Dev\BuildTask;
use SilverStripe\PolyExecution\PolyOutput;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\InputInterface;

class MockHashLinkPageTask extends BuildTask
{
    protected string $title = 'Create mock hash link page';
    protected static string $description = 'Creates a mock page containing an in-page hash link';
    protected function execute(InputInterface $input, PolyOutput $output): int
    {
        foreach (SiteTree::get()->filter('URLSegment', 'mock-hash-link-page') as $existing) {
            $existing->doUnpublish();
            $existing->delete();
        }
        $page = SiteTree::create();
        $page->Title = 'Mock Hash Link Page';
        $page->URLSegment = 'mock-hash-link-page';
        $page->Content = '<p><a href="#anchor">Jump</a></p><p id="anchor">Target</p>';
        $page->write();
        $page->publishRecursive();
        return Command::SUCCESS;
    }
}
```
