### PR TITLE
FIX Shorthand Injector aliases now resolve concrete classes

### DIFF
--- a/src/Core/Injector/SilverStripeServiceConfigurationLocator.php
+++ b/src/Core/Injector/SilverStripeServiceConfigurationLocator.php
@@ -31,7 +31,17 @@ class SilverStripeServiceConfigurationLocator implements ServiceConfigurationLoc
         // If config is in `%$Source` format then inherit from the named config
         if (is_string($config) && stripos($config ?? '', '%$') === 0) {
             $name = substr($config ?? '', 2);
-            return $this->locateConfigFor($name);
+            $inheritedConfig = $this->locateConfigFor($name);
+            if ($inheritedConfig) {
+                return $inheritedConfig;
+            }
+
+            // No explicit config for the referenced service, but it's a real class, so alias to it directly.
+            if (class_exists($name)) {
+                return ['class' => $name];
+            }
+
+            return null;
         }
 
         // Return the located config

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -769,6 +769,19 @@ class InjectorTest extends SapphireTest
         $this->assertEquals($obj->one, 'the one');
     }
 
+    public function testAliasToClassWithoutExplicitInjectorConfig()
+    {
+        $injector = new Injector(['locator' => SilverStripeServiceConfigurationLocator::class]);
+        Config::modify()->set(
+            Injector::class,
+            'MyAliasedService',
+            '%$' . MyParentClass::class
+        );
+
+        $obj = $injector->get('MyAliasedService');
+        $this->assertInstanceOf(MyParentClass::class, $obj);
+    }
+
     public function testSameNamedSingeltonPrototype()
     {
         $injector = new Injector();


### PR DESCRIPTION
When defining a top level service class alias shorthand, Injector now resolves correctly if it's a concrete class, without requiring an alias defined for it.
    
e.g.
```
SilverStripe\Core\Injector\Injector:
  MyNamespace\Gateway: '%$MyNamespace\NullGateway'
```
    
Doesn't apply to `%$ClassName` references elsewhere, which already go through `Injector::convertServiceProperty` / `get()` rather than `SilverStripeServiceConfigurationLocator`.

Fixes https://github.com/silverstripe/silverstripe-framework/issues/11595