### PR TITLE
FIX Resolve table class when multiple modifiers are appended

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -274,8 +274,9 @@ class DataObjectSchema
         }
 
         // If there is no class for this table, strip table modifiers (e.g. _Live / _Versions)
-        // from the end and re-attempt a search.
-        if (preg_match('/^(?<class>.+)(_[^_]+)$/i', $table ?? '', $matches)) {
+        // from the end and re-attempt a search. Repeat until no more modifiers left, supports
+        // tables with multiple suffixes e.g. `_Localised_Live` with Fluent and Versioned.
+        while (preg_match('/^(?<class>.+)(_[^_]+)$/i', $table ?? '', $matches)) {
             $table = $matches['class'];
             $class = array_search($table, $tables ?? [], true);
             if ($class) {

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -84,6 +84,15 @@ class DataObjectSchemaTest extends SapphireTest
             WithCustomTable::class,
             $schema->tableClass('DOSTWithCustomTable')
         );
+
+        $this->assertEquals(
+            WithRelation::class,
+            $schema->tableClass('DataObjectSchemaTest_WithRelation_Localised_Live')
+        );
+        $this->assertEquals(
+            WithRelation::class,
+            $schema->tableClass('DataObjectSchemaTest_WithRelation_Localised_Versions')
+        );
     }
 
     public function testTableForObjectField()


### PR DESCRIPTION
For example, when using Versioned and Fluent together with `DBSchemaManager::$exclude_models_from_db_checks` enabled.

## Issues

Fixes https://github.com/silverstripe/silverstripe-framework/issues/11978


## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
