### PR TITLE
FIX isQueryType fails when sql starts with whitespace

### DIFF
--- a/src/ORM/Connect/DBConnector.php
+++ b/src/ORM/Connect/DBConnector.php
@@ -149,14 +149,15 @@ abstract class DBConnector
      */
     protected function isQueryType($sql, $type)
     {
-        if (!preg_match('/^(?<operation>\w+)\b/', $sql ?? '', $matches)) {
+        $sql = trim($sql ?? '');
+        if (!preg_match('/^(?<operation>\w+)\b/', $sql, $matches)) {
             return false;
         }
-        $operation = $matches['operation'];
+        $operation = strtolower($matches['operation']);
         if (is_array($type)) {
-            return in_array(strtolower($operation ?? ''), $type ?? []);
+            return in_array($operation, $type, true);
         }
-        return strcasecmp($sql ?? '', $type ?? '') === 0;
+        return $operation === $type;
     }
 
     /**

--- a/tests/php/ORM/DBReplicaTest.php
+++ b/tests/php/ORM/DBReplicaTest.php
@@ -2,18 +2,18 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
-use SilverStripe\Dev\FunctionalTest;
-use SilverStripe\ORM\DB;
 use SilverStripe\Control\Director;
-use SilverStripe\Security\Security;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Tests\DBReplicaTest\TestController;
 use SilverStripe\ORM\Tests\DBReplicaTest\TestObject;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
-use SilverStripe\ORM\DataQuery;
-use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Security\Security;
 
 class DBReplicaTest extends FunctionalTest
 {
@@ -42,7 +42,7 @@ class DBReplicaTest extends FunctionalTest
         (new ReflectionClass(DB::class))->setStaticPropertyValue('mustUsePrimary', true);
         parent::tearDown();
     }
-    
+
     public function testUsesReplica(): void
     {
         // Assert uses replica by default
@@ -68,6 +68,51 @@ class DBReplicaTest extends FunctionalTest
         // Assert that now all subsequent queries use primary
         TestObject::get()->count();
         $this->assertSame(DB::CONN_PRIMARY, $this->getLastConnectionName());
+    }
+
+    public static function provideQueriesWithType(): array
+    {
+        return [
+            'select' => ['SELECT "ID" FROM "DBReplicaTest_TestObject"', false],
+            'select whitespace' => ['    SELECT "ID" FROM "DBReplicaTest_TestObject"', false],
+            'select tabs' => ["\t" . 'SELECT "ID" FROM "DBReplicaTest_TestObject"', false],
+            'select newlines' => ["\n" . 'SELECT "ID" FROM "DBReplicaTest_TestObject"', false],
+
+            'insert' => ['INSERT INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+            'insert whitespace' => ['   INSERT INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+            'insert tabs' => ["\t" . 'INSERT INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+            'insert newlines' => ["\n" . 'INSERT INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+
+            'replace' => ['REPLACE INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+            'replace whitespace' => ['   REPLACE INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+            'replace tabs' => ["\t" . 'REPLACE INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+            'replace newlines' => ["\n" . 'REPLACE INTO "DBReplicaTest_TestObject" ("Title") VALUES (?)', true],
+
+            'update' => ['UPDATE "DBReplicaTest_TestObject" SET "Title" = ?', true],
+            'update whitespace' => ['   UPDATE "DBReplicaTest_TestObject" SET "Title" = ?', true],
+            'update tabs' => ["\t" . 'UPDATE "DBReplicaTest_TestObject" SET "Title" = ?', true],
+            'update newlines' => ["\n" . 'UPDATE "DBReplicaTest_TestObject" SET "Title" = ?', true],
+
+            'delete' => ['DELETE FROM "DBReplicaTest_TestObject"', true],
+            'delete whitespace' => ['   DELETE FROM "DBReplicaTest_TestObject"', true],
+            'delete tabs' => ["\t" . 'DELETE FROM "DBReplicaTest_TestObject"', true],
+            'delete newlines' => ["\n" . 'DELETE FROM "DBReplicaTest_TestObject"', true],
+
+            'create table' => ['CREATE TABLE "DBReplicaTest_TestObject" ("ID" int primary key)', true],
+            'create table whitespace' => ['  CREATE TABLE "DBReplicaTest_TestObject" ("ID" int primary key)', true],
+
+            'drop table' => ['DROP TABLE "DBReplicaTest_TestObject"', true],
+            'drop table whitespace' => ['  DROP TABLE "DBReplicaTest_TestObject"', true],
+
+            'alter table' => ['ALTER TABLE "DBReplicaTest_TestObject" ADD COLUMN "Foo" INT', true],
+            'alter table whitespace' => ['  ALTER TABLE "DBReplicaTest_TestObject" ADD COLUMN "Foo" INT', true],
+        ];
+    }
+
+    #[DataProvider('provideQueriesWithType')]
+    public function testQueryType(string $query, bool $mutable): void
+    {
+        self::assertSame($mutable, DB::get_connector()->isQueryMutable($query));
     }
 
     public function testMutableSqlDbQuery(): void


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

The isQueryType method checks is a sql statements begins with a given keyword. But this currently fails if the sql statements starts with a whitespace.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

```php
        var_dump(DB::get_connector()->isQueryMutable('
            INSERT INTO "Foobar" ("Title")
            VALUES (\'Hallo\')
        '));
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #12010

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
