### PR TITLE
FIX Null array offset in readonly TreeDropdownField on PHP 8.5

### DIFF
--- a/src/Forms/TreeDropdownField_Readonly.php
+++ b/src/Forms/TreeDropdownField_Readonly.php
@@ -12,11 +12,13 @@ class TreeDropdownField_Readonly extends TreeDropdownField
         if ($this->value) {
             $keyObj = $this->objectForKey($this->value);
             $title = $keyObj ? $keyObj->$fieldName : '';
+            $source = [$this->value => $title];
         } else {
-            $title = null;
+            // Using null as an array offset is deprecated in PHP 8.5. An empty
+            // source renders the same "(none)" placeholder LookupField produced
+            // for the previous [null => null] source.
+            $source = [];
         }
-
-        $source = [ $this->value => $title ];
         $field = LookupField::create($this->name, $this->title, $source);
         $field->setValue($this->value);
         $field->setForm($this->form);

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -332,6 +332,20 @@ class TreeDropdownFieldTest extends SapphireTest
         );
     }
 
+    public function testReadonlyWithoutValue()
+    {
+        // Rendering without a value used a null array offset for the LookupField
+        // source, which PHP 8.5 deprecates (fatal in dev environments)
+        $field = new TreeDropdownField('TestTree', 'Test tree', File::class);
+        $readonly = $field->performReadonlyTransformation();
+        $this->assertXmlStringEqualsXmlString(
+            $this->toXml('<span class="readonly" id="TestTree" role="textbox" aria-readonly="true" tabindex="0">'
+            . '<i>(none)</i></span>'
+            . '<input type="hidden" name="TestTree" value="" />'),
+            $this->toXml((string) $readonly->Field())
+        );
+    }
+
     /**
      * This is to test setting $key to an Object in the protected function objectForKey()
      * This is to fix an issue where postgres will not fail gracefully when you do this


### PR DESCRIPTION
## Description

`TreeDropdownField_Readonly::Field()` builds its `LookupField` source as `[$this->value => $title]`. When the field has no value, both are `null`, so the source is `[null => null]`. PHP 8.5 deprecates using `null` as an array offset, and dev environments escalate the deprecation to a fatal error - any screen rendering a valueless readonly tree field breaks (the easiest reproduction is viewing an archived top-level page in ArchiveAdmin, whose readonly `ParentID` has no value).

Expected: the field renders its *(none)* placeholder, as it did before PHP 8.5.
Observed on PHP 8.5 dev: `[Deprecated] Using null as an array offset is deprecated, use an empty string instead` -> fatal.

The fix builds the one-entry source only when a value exists and uses an empty source otherwise. `LookupField` renders the identical *(none)* placeholder and `value=""` hidden input for an empty source that it rendered for `[null => null]`, so output is unchanged on every PHP version.

## Manual testing steps

On PHP 8.5 with `SS_ENVIRONMENT_TYPE="dev"`:

1. Archive any top-level page.
2. Open Archived Items (`/admin/archive/`) and view the archived page.
3. Without this fix the request dies on the deprecation from `TreeDropdownField_Readonly::Field()`; with it, the record view renders and the Parent Page field shows *(none)*.

## Issues

- #12014

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release (no docs/changelog impact - behaviour-preserving bug fix)
- [ ] CI is green (runs once the PR is opened)
