### PR TITLE
Remove the duplicated E_CORE_ERROR entry in DebugView

### DIFF
--- a/src/Dev/DebugView.php
+++ b/src/Dev/DebugView.php
@@ -86,10 +86,6 @@ class DebugView
             'title' => 'User Deprecated',
             'class' => 'notice'
         ],
-        E_CORE_ERROR => [
-            'title' => 'Core Error',
-            'class' => 'error'
-        ],
         E_WARNING => [
             'title' => 'Warning',
             'class' => 'warning'


### PR DESCRIPTION
## Description

`E_CORE_ERROR` is written twice in the `$error_types` array in `DebugView`, once between `E_USER_ERROR` and `E_NOTICE` and again twenty lines down before `E_WARNING`. The two blocks are identical. PHP keeps the first position and the last value for a repeated key, so the second block has never changed what the array holds, it only makes the table look like it covers something it already covered.

## Manual testing steps

There is nothing to observe, the resulting array is the same as before in both values and key order. I dropped the second occurrence rather than the first for exactly that reason.

## Issues

None, found by reading.
